### PR TITLE
Improve docker compose example

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,21 +96,24 @@ The architectures supported by this image are:
    
    or as Docker Compose:
    ```bash
-   version: '3.8'
-    services:
-      bambulab-ams-spoolman-filamentstatus:
-        image: ghcr.io/rdiger-36/bambulab-ams-spoolman-filamentstatus:latest
-        container_name: bambulab-ams-spoolman-filamentstatus
-        ports:
-          - 4000:4000
-        environment:
-          - SPOOLMAN_IP=<spoolman_ip_address>
-          - SPOOLMAN_PORT=<spoolman_port>
-          - UPDATE_INTERVAL=120000
-          - MODE=automatic
-        volumes:
-          - /path/to/your/config/printers:/app/printers
-        restart: unless-stopped
+  services:
+    bambulab-ams-spoolman-filamentstatus:
+      image: ghcr.io/rdiger-36/bambulab-ams-spoolman-filamentstatus:latest
+      container_name: bambulab-ams-spoolman-filamentstatus
+      depends_on:
+        spoolman:
+          condition: service_started
+          restart: true
+      ports:
+        - 4000:4000
+      environment:
+        - SPOOLMAN_IP=<spoolman_ip_address>
+        - SPOOLMAN_PORT=<spoolman_port>
+        - UPDATE_INTERVAL=120000
+        - MODE=automatic
+      volumes:
+        - /path/to/your/config/printers:/app/printers
+      restart: unless-stopped
    ```
 
 ## Environment Variables


### PR DESCRIPTION
### Remove the `version` top-level element

The `version` top-level element has been obsoleted and should be removed as it results in a warning on start. See [docs](https://docs.docker.com/reference/compose-file/version-and-name/#version-top-level-element-obsolete) for details.

### Add `depends_on` attribute

(Re)starting both containers, `spoolman` and `bambulab-ams-spoolman-filamentstatus`, at the same time results in a connection error:
```
Server - Error starting the service: RequestError: connect ECONNREFUSED 172.18.0.7:8000
```

It seems there is no connection retry logic implemented if `spoolman` is unreachable at start. So I'd propose to add a `depends_on` attribute to the compose example to guarantee that `spoolman` is up and running.

A retry connection logic would be a valuable enhancement though.