### PR TITLE
Release 1.2.0-dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 -----------------------------------------------------------------------------------------------
+Version 1.2.0-dev
+   - Bugfixes:
+      - Fix: Empty AMS slots reported by the printer with N/A values (tray_uuid, tray_sub_brands, tray_color) and tray_weight 0 were incorrectly displayed as "Loaded (3rd party)" instead of "Empty"
+         - The slot detection now distinguishes between truly empty slots (tray_weight = 0 + N/A values) and actual 3rd party spools (N/A values but with a valid weight)
+-----------------------------------------------------------------------------------------------
 Version 1.1.1-dev
    - Changes:
       - Better handling for multiple AMS-HT 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bambulab-ams-spoolman-filamentstatus",
-  "version": "1.0.9",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bambulab-ams-spoolman-filamentstatus",
-      "version": "1.0.9",
+      "version": "1.2.0",
       "license": "ISC",
       "dependencies": {
         "async-mqtt": "^2.6.3",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "got": "^14.6.6"
   },
   "name": "bambulab-ams-spoolman-filamentstatus",
-  "version": "1.0.9",
+  "version": "1.2.0",
   "main": "app.js",
   "type": "module",
   "scripts": {

--- a/src/config.js
+++ b/src/config.js
@@ -10,7 +10,7 @@ export const __rootDir = path.dirname(path.dirname(__filename));
 export const serverLogFilePath = path.join(__rootDir, "logs", "server.log");
 export const configPath = path.resolve(__rootDir, "printers", "printers.json");
 
-export const version = "1.1.2-dev";
+export const version = "1.2.0-dev";
 export const PORT = 4000;
 
 export const PRINTER_ID = process.env.PRINTER_ID;

--- a/src/mqtt.js
+++ b/src/mqtt.js
@@ -193,6 +193,14 @@ async function processSlot(printer, ams, slot, spools, externalFilaments, intern
         return;
     }
 
+    if ((slot.tray_uuid === "N/A" || slot.tray_sub_brands === "N/A") && (slot.tray_weight === 0 || slot.tray_weight === "0")) {
+        console.debug(printer.name, printer.logFilePath, "No Data found in Slots (empty slot with N/A values)");
+        const newUiSpool = buildEmptySpool(printer, amsId, slot);
+        await clearLocationIfSpoolChanged(printer, amsId, null, prevByAmsId);
+        pushSlotUpdate(printer, newUiSpool, prevByAmsId, slot);
+        return;
+    }
+
     if (slot.tray_uuid === "N/A" || slot.tray_sub_brands === "N/A") {
         console.debug(printer.name, printer.logFilePath, "Slot is read-only (3rd party spool)");
         slot.tray_sub_brands = slot.tray_type;


### PR DESCRIPTION
## Summary
- Bump version to `1.2.0-dev` (package.json, config.js)
- Fix: Empty AMS slots with N/A values and `tray_weight=0` were incorrectly shown as **Loaded (3rd party)** — now correctly classified as **Empty**
- Updated CHANGELOG.md

## Root cause
The P2S reports empty slots with 7 keys including `tray_uuid: "N/A"`, `tray_sub_brands: "N/A"`, and `tray_weight: 0`. The previous `validSlot` guard (key count > 6) passed these through to the 3rd-party branch. The fix adds an explicit empty-slot check before the 3rd-party branch: N/A values **and** `tray_weight === 0` → Empty.

## Test plan
- [x] Start service with a printer that has empty AMS slots
- [x] Confirm empty slots show as "Empty" in the dashboard instead of "Loaded (3rd party)"
- [x] Confirm real 3rd party spools (N/A UUID but weight > 0) still show as "Loaded (3rd party)"

🤖 Generated with [Claude Code](https://claude.com/claude-code)