### PR TITLE
fix: correctly detect 3rd party spools with tray_weight=0

### DIFF
--- a/src/mqtt.js
+++ b/src/mqtt.js
@@ -193,7 +193,7 @@ async function processSlot(printer, ams, slot, spools, externalFilaments, intern
         return;
     }
 
-    if ((slot.tray_uuid === "N/A" || slot.tray_sub_brands === "N/A") && (slot.tray_weight === 0 || slot.tray_weight === "0")) {
+    if ((slot.tray_uuid === "N/A" || slot.tray_sub_brands === "N/A") && (slot.tray_weight === 0 || slot.tray_weight === "0") && (!slot.tray_type || slot.tray_type === "")) {
         console.debug(printer.name, printer.logFilePath, "No Data found in Slots (empty slot with N/A values)");
         const newUiSpool = buildEmptySpool(printer, amsId, slot);
         await clearLocationIfSpoolChanged(printer, amsId, null, prevByAmsId);


### PR DESCRIPTION
## Summary

- 3rd party spools (no RFID chip) always have `tray_weight=0` because Bambu cannot read weight data without a tag
- The previous empty-slot check (`uuid=N/A || sub_brands=N/A`) + `weight=0` incorrectly classified loaded 3rd party spools as empty slots
- Added a `tray_type` check to the empty-slot condition: truly empty slots have an empty `tray_type` string, whereas 3rd party spools always report a valid material type (e.g. `"PLA"`, `"PETG"`)

## What changed

`src/mqtt.js` — the empty-slot early-return condition now additionally requires `tray_type` to be empty:

```js
// before
(uuid === "N/A" || sub_brands === "N/A") && weight === 0

// after
(uuid === "N/A" || sub_brands === "N/A") && weight === 0 && (!tray_type || tray_type === "")
```

## Classification matrix after this fix

| Type | `tray_uuid` | `tray_weight` | `tray_type` | Result |
|---|---|---|---|---|
| Empty slot | N/A | 0 | `""` | → Empty ✓ |
| 3rd party spool | N/A | 0 | `"PLA"` etc. | → 3rd party ✓ |
| Bambu spool | real UUID | 1000 | `"PETG"` etc. | → Bambu ✓ |

## Root cause

Introduced by the fix in `e217933` (v1.2.0): the weight=0 guard was too broad — it matched both empty slots and 3rd party spools.

🤖 Generated with [Claude Code](https://claude.com/claude-code)