### PR TITLE
Release v1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 -----------------------------------------------------------------------------------------------
+Version 1.2.1
+   - Bugfixes:
+      - Fix: 3rd party spools (no RFID chip) with tray_weight=0 were incorrectly displayed as "Empty" instead of "Loaded (3rd party)"
+         - 3rd party spools have no RFID chip and therefore always report tray_weight=0, which caused them to match the empty-slot detection introduced in v1.2.0
+         - The empty-slot detection now additionally checks that tray_type is empty, which correctly distinguishes truly empty slots from loaded 3rd party spools
+-----------------------------------------------------------------------------------------------
 Version 1.2.0
    - New Features:
       - New ENV SET_LOCATION: automatically syncs the spool location in Spoolman with the current AMS slot (e.g. "Bambu Lab P1S - A0") when a spool is detected

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bambulab-ams-spoolman-filamentstatus",
-  "version": "1.2.1-dev",
+  "version": "1.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bambulab-ams-spoolman-filamentstatus",
-      "version": "1.2.1-dev",
+      "version": "1.2.1",
       "license": "ISC",
       "dependencies": {
         "async-mqtt": "^2.6.3",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "got": "^14.6.6"
   },
   "name": "bambulab-ams-spoolman-filamentstatus",
-  "version": "1.2.1-dev",
+  "version": "1.2.1",
   "main": "app.js",
   "type": "module",
   "scripts": {

--- a/src/config.js
+++ b/src/config.js
@@ -10,7 +10,7 @@ export const __rootDir = path.dirname(path.dirname(__filename));
 export const serverLogFilePath = path.join(__rootDir, "logs", "server.log");
 export const configPath = path.resolve(__rootDir, "printers", "printers.json");
 
-export const version = "1.2.0";
+export const version = "1.2.1";
 export const PORT = 4000;
 
 export const PRINTER_ID = process.env.PRINTER_ID;


### PR DESCRIPTION
## Summary

- Bump version to 1.2.1 across all files (`package.json`, `package-lock.json`, `src/config.js`)
- Add CHANGELOG entry for v1.2.1

## Bugfix included

**3rd party spools incorrectly shown as empty slots**

Spools without an RFID chip always report `tray_weight=0` (no tag = no weight data from Bambu). The empty-slot guard introduced in v1.2.0 matched on `(uuid=N/A || sub_brands=N/A) && weight=0`, which caused loaded 3rd party spools to be classified as empty instead of "Loaded (3rd party)".

Fix: added a `tray_type` check — truly empty slots have an empty `tray_type`, while 3rd party spools always carry a valid material type (e.g. `PLA`).

## Files changed

| File | Change |
|---|---|
| `src/mqtt.js` | Empty-slot condition extended with `tray_type` check |
| `src/config.js` | Version `1.2.0` → `1.2.1` |
| `package.json` | Version `1.2.1-dev` → `1.2.1` |
| `package-lock.json` | Version `1.2.1-dev` → `1.2.1` |
| `CHANGELOG.md` | New entry for v1.2.1 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)