### PR TITLE
chore: bump the version to 1.3.0-dev.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 -----------------------------------------------------------------------------------------------
-Version 1.3.0-dev
+Version 1.3.0-dev.2
    - New Features:
       - Filament consumption is now tracked from the sliced G-code instead of the AMS RFID remain percentage
          - While a print runs, the sliced .gcode.3mf is downloaded from the printer via FTPS (port 990, same access code as MQTT) and the needed grams per filament are read from Metadata/slice_info.config

--- a/OPEN.md
+++ b/OPEN.md
@@ -93,7 +93,8 @@ None of this involved real hardware, so it says nothing about the items above.
 
 ## Before the next official release
 
-The version deliberately stays at `1.3.0-dev` for now.
+The version deliberately stays on a `-dev` prerelease for now, currently
+`1.3.0-dev.2`.
 
 - [ ] Set the version to `1.3.0` in **both** `package.json` and `src/config.js`.
   The publish workflow compares the tag against `package.json` and aborts on a

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bambulab-ams-spoolman-filamentstatus",
-  "version": "1.3.0-dev",
+  "version": "1.3.0-dev.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bambulab-ams-spoolman-filamentstatus",
-      "version": "1.3.0-dev",
+      "version": "1.3.0-dev.2",
       "license": "ISC",
       "dependencies": {
         "adm-zip": "^0.6.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "mqtt": "^5.15.2"
   },
   "name": "bambulab-ams-spoolman-filamentstatus",
-  "version": "1.3.0-dev",
+  "version": "1.3.0-dev.2",
   "main": "app.js",
   "type": "module",
   "engines": {

--- a/src/config.js
+++ b/src/config.js
@@ -29,7 +29,7 @@ export const settingsPath = path.join(dataDir, "settings.json");
 // brings the service back on its own or depends on the container policy.
 export const supervised = process.env.SUPERVISED === "1";
 
-export const version = "1.3.0-dev";
+export const version = "1.3.0-dev.2";
 export const PORT = 4000;
 export const RECONNECT_INTERVAL = 60000;
 


### PR DESCRIPTION
Sets the version to `1.3.0-dev.2`, so the settings UI work merged in #81 can be published as a prerelease image.

## What changed

- `package.json` and `package-lock.json`, via `npm version --no-git-tag-version` (no tag was created here)
- `src/config.js`, which is the version the Web UI reports in its footer
- The CHANGELOG heading and the sentence in `OPEN.md` that still named `1.3.0-dev`

## Why all of them

The publish workflow compares the tag against `package.json` and aborts on a mismatch, and `src/config.js` is what users see. Bumping only one of the two either fails the build or ships an image that reports the wrong version.

## For the reviewer

Nothing in the runtime behaviour changes. After merging, tagging `v1.3.0-dev.2` publishes `:1.3.0-dev.2` and moves the rolling `:dev` tag; `:latest` stays where it is, because the workflow only moves it for a version without a suffix.

The release itself still needs the bump to `1.3.0` in both files, which is tracked in `OPEN.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
