### PR TITLE
chore: bump the version to 1.3.0-dev.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,15 @@
 -----------------------------------------------------------------------------------------------
+Version 1.3.0-dev.3
+   - Documentation:
+      - The README is rebuilt around G-code tracking, which is the default since 1.3.0
+         - Legacy mode has a section of its own and points at the README of v1.2.1 for the behaviour, the Web UI and the configuration it describes
+         - The environment variable table and the printers.json format are gone. Both still work, but a variable only seeds a setting that has never been saved, so "Deprecated configuration" says that and links the old README for the full list
+         - The three container level variables that have no field in the Web UI (TZ, DATA_DIR/LOG_DIR, SUPERVISOR) are listed separately, because they are not deprecated
+         - Fixed what no longer matched the code: the log example was legacy output, the state legend belonged to the classic AMS table that G-code mode replaces, tray_info_idx was wrong in the examples, and the Node badge said 18 while package.json requires 22
+         - Added what booking per print rather than per AMS report implies: a slot needs a link before anything is booked, nothing is written to Spoolman while the print runs, and without FTPS access nothing is booked at all
+      - New screenshots taken from 1.3.0, stored in docs/images next to the text instead of as uploaded attachments
+
+-----------------------------------------------------------------------------------------------
 Version 1.3.0-dev.2
    - New Features:
       - Filament consumption is now tracked from the sliced G-code instead of the AMS RFID remain percentage

--- a/OPEN.md
+++ b/OPEN.md
@@ -121,7 +121,7 @@ None of this involved real hardware, so it says nothing about the items above.
 ## Before the next official release
 
 The version deliberately stays on a `-dev` prerelease for now, currently
-`1.3.0-dev.2`.
+`1.3.0-dev.3`.
 
 - [ ] Set the version to `1.3.0` in **both** `package.json` and `src/config.js`.
   The publish workflow compares the tag against `package.json` and aborts on a
@@ -132,7 +132,7 @@ Tag behaviour, after the hardening in `c053561`:
 | Tag | Images | `:latest` |
 |---|---|---|
 | `v1.3.0` | `:1.3.0` and `:latest` | moved |
-| `v1.3.0-dev`, `v1.3.0-dev.2` | `:<version>` and `:dev` | untouched |
+| `v1.3.0-dev`, `v1.3.0-dev.2`, `v1.3.0-dev.3` | `:<version>` and `:dev` | untouched |
 | `v1.3.0-rc1` and other suffixes | `:<version>` only | untouched |
 
 Publishing from a branch is rejected outright, so the "Run workflow" button can

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bambulab-ams-spoolman-filamentstatus",
-  "version": "1.3.0-dev.2",
+  "version": "1.3.0-dev.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bambulab-ams-spoolman-filamentstatus",
-      "version": "1.3.0-dev.2",
+      "version": "1.3.0-dev.3",
       "license": "ISC",
       "dependencies": {
         "adm-zip": "^0.6.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "mqtt": "^5.15.2"
   },
   "name": "bambulab-ams-spoolman-filamentstatus",
-  "version": "1.3.0-dev.2",
+  "version": "1.3.0-dev.3",
   "main": "app.js",
   "type": "module",
   "engines": {

--- a/src/config.js
+++ b/src/config.js
@@ -29,7 +29,7 @@ export const settingsPath = path.join(dataDir, "settings.json");
 // brings the service back on its own or depends on the container policy.
 export const supervised = process.env.SUPERVISED === "1";
 
-export const version = "1.3.0-dev.2";
+export const version = "1.3.0-dev.3";
 export const PORT = 4000;
 export const RECONNECT_INTERVAL = 60000;
 


### PR DESCRIPTION
Bumps `package.json`, `package-lock.json` and `src/config.js` together. The publish workflow compares the tag against `package.json` (`.github/workflows/docker-publish.yml:62`) and aborts on a mismatch, while `src/config.js` is what the Web UI and the diagnostics bundle report — a bump in only one of them either fails the build or ships an image that lies about its version.

Also:

- A changelog entry for the README rebuild that went in since dev.2 (#83 → #84).
- The tag table in `OPEN.md` lists `v1.3.0-dev.3`, and the "currently" line points at the new prerelease.

Still a `-dev` prerelease, so tagging this publishes `:1.3.0-dev.3` and `:dev` and leaves `:latest` alone.

`npm test`: 152 passing, 0 failing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)