### PR TITLE
feat: publish a GitHub release from the tag that builds the image

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -15,7 +15,9 @@ jobs:
   build-and-push:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      # The release step writes to the repository's releases, the image push
+      # writes to the package registry.
+      contents: write
       packages: write
 
     steps:
@@ -69,15 +71,19 @@ jobs:
           # suffix additionally moves the rolling :dev tag, further iterations
           # (-dev.2 and so on) included. Any other suffix publishes its exact
           # version only, so an -rc or -beta cannot reach users on :latest.
+          # The same suffix that keeps a version off :latest also makes its
+          # GitHub release a pre-release, so the two cannot drift apart: an
+          # image that is not :latest is never the release users are pointed at.
           case "${VERSION}" in
-            *-dev|*-dev.*) TAGS="${IMAGE}:${VERSION},${IMAGE}:dev" ;;
-            *-*)           TAGS="${IMAGE}:${VERSION}" ;;
-            *)             TAGS="${IMAGE}:${VERSION},${IMAGE}:latest" ;;
+            *-dev|*-dev.*) TAGS="${IMAGE}:${VERSION},${IMAGE}:dev"    ; PRERELEASE=true  ;;
+            *-*)           TAGS="${IMAGE}:${VERSION}"                 ; PRERELEASE=true  ;;
+            *)             TAGS="${IMAGE}:${VERSION},${IMAGE}:latest" ; PRERELEASE=false ;;
           esac
 
-          echo "Publishing: ${TAGS}"
+          echo "Publishing: ${TAGS} (prerelease: ${PRERELEASE})"
           echo "tags=${TAGS}" >> $GITHUB_OUTPUT
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          echo "prerelease=${PRERELEASE}" >> $GITHUB_OUTPUT
           # Build time for the OCI created label. The repository's updated_at
           # was used here, which is when the repo last changed, not when this
           # image was built.
@@ -99,3 +105,71 @@ jobs:
             org.opencontainers.image.created=${{ steps.tags.outputs.created }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      # Runs after the push on purpose: a release that points at an image which
+      # never got built would send people to a pull that fails.
+      - name: Publish the GitHub release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.tags.outputs.version }}
+          PRERELEASE: ${{ steps.tags.outputs.prerelease }}
+          TAGS: ${{ steps.tags.outputs.tags }}
+        run: |
+          set -euo pipefail
+
+          # The section of CHANGELOG.md for exactly this version: everything
+          # between its "Version <x>" line and the next separator. An exact
+          # string compare rather than a pattern, so 1.3.0 cannot match the
+          # heading of 1.3.0-dev.2. The separator is matched as "starts with
+          # ---" rather than by a counted interval, which mawk, the awk on the
+          # runner, does not support.
+          NOTES="$(awk -v v="Version ${VERSION}" '
+            $0 == v { found = 1; next }
+            found && /^---/ { exit }
+            found { print }
+          ' CHANGELOG.md)"
+
+          {
+            if [[ -n "${NOTES//[[:space:]]/}" ]]; then
+              # Fenced, because the changelog is indented plain text: as
+              # markdown its deeper levels would collapse into code blocks
+              # halfway and read as a mess.
+              echo '```'
+              printf '%s\n' "${NOTES}"
+              echo '```'
+            else
+              echo "No CHANGELOG.md section for ${VERSION}."
+            fi
+
+            echo
+            echo "### Docker"
+            echo
+            echo '```bash'
+            # Every tag this run published, so the notes cannot claim a tag that
+            # was not pushed: for a stable version that is :latest as well.
+            echo "${TAGS}" | tr ',' '\n' | while read -r tag; do
+              [[ -n "${tag}" ]] && echo "docker pull ${tag}"
+            done
+            echo '```'
+            if [[ "${PRERELEASE}" == "true" ]]; then
+              echo
+              echo "This is a pre-release. \`:latest\` still points at the last stable version."
+            fi
+          } > release-notes.md
+
+          # A re-run of the workflow for a tag that already has a release should
+          # update it rather than fail on the second attempt.
+          if gh release view "${GITHUB_REF_NAME}" >/dev/null 2>&1; then
+            gh release edit "${GITHUB_REF_NAME}" \
+              --notes-file release-notes.md \
+              --prerelease="${PRERELEASE}" \
+              --latest="$([[ "${PRERELEASE}" == "true" ]] && echo false || echo true)"
+            echo "Updated the existing release ${GITHUB_REF_NAME}."
+          else
+            gh release create "${GITHUB_REF_NAME}" \
+              --title "${GITHUB_REF_NAME}" \
+              --notes-file release-notes.md \
+              --prerelease="${PRERELEASE}" \
+              --latest="$([[ "${PRERELEASE}" == "true" ]] && echo false || echo true)"
+            echo "Created the release ${GITHUB_REF_NAME} (prerelease: ${PRERELEASE})."
+          fi

--- a/OPEN.md
+++ b/OPEN.md
@@ -129,11 +129,20 @@ The version deliberately stays on a `-dev` prerelease for now, currently
 
 Tag behaviour, after the hardening in `c053561`:
 
-| Tag | Images | `:latest` |
-|---|---|---|
-| `v1.3.0` | `:1.3.0` and `:latest` | moved |
-| `v1.3.0-dev`, `v1.3.0-dev.2`, `v1.3.0-dev.3` | `:<version>` and `:dev` | untouched |
-| `v1.3.0-rc1` and other suffixes | `:<version>` only | untouched |
+| Tag | Images | `:latest` | GitHub release |
+|---|---|---|---|
+| `v1.3.0` | `:1.3.0` and `:latest` | moved | release, marked Latest |
+| `v1.3.0-dev`, `v1.3.0-dev.2`, `v1.3.0-dev.3` | `:<version>` and `:dev` | untouched | pre-release |
+| `v1.3.0-rc1` and other suffixes | `:<version>` only | untouched | pre-release |
+
+One `case` decides all four columns, so the image tags and the release cannot
+disagree: whatever does not move `:latest` is a pre-release.
+
+The release is written after the image push, not before, because a release
+pointing at an image that never built sends people to a pull that fails. Its
+body is the section of `CHANGELOG.md` for exactly that version, so a release
+without a changelog entry says so instead of inventing notes. A re-run for a
+tag that already has a release edits it rather than failing.
 
 Publishing from a branch is rejected outright, so the "Run workflow" button can
 no longer overwrite `:latest` with whatever is on `main`.


### PR DESCRIPTION
The workflow pushed images and stopped there, so every release had to be written by hand afterwards, or not at all.

## What decides what

The `case` that already decided the image tags now decides the release kind too, so the two cannot drift apart — a version whose suffix keeps it off `:latest` is exactly the version that is published as a pre-release:

| Tag | Images | `:latest` | GitHub release |
|---|---|---|---|
| `v1.3.0` | `:1.3.0` and `:latest` | moved | release, marked Latest |
| `v1.3.0-dev`, `v1.3.0-dev.2`, … | `:<version>` and `:dev` | untouched | pre-release |
| `v1.3.0-rc1` and other suffixes | `:<version>` only | untouched | pre-release |

## Details worth knowing

- **Runs after the image push, not before.** A release pointing at an image that never got built sends people to a `docker pull` that fails.
- **The body is the `CHANGELOG.md` section for exactly that version**, matched by an exact string compare so `1.3.0` cannot pick up the heading of `1.3.0-dev.2`. It is fenced, because the changelog is indented plain text whose deeper levels would otherwise collapse into code blocks halfway through. A version without a changelog entry says so rather than shipping empty notes.
- Under it, **one `docker pull` line per tag this run actually pushed** — for a stable version that includes `:latest`.
- **A re-run for a tag that already has a release edits it** instead of failing on the second attempt.
- `permissions.contents` goes `read` → `write`, which the release needs.
- The changelog separator is matched as "starts with `---`" rather than by a counted interval `{10,}`, which mawk — the `awk` on the runner — does not support.

## Verified

The notes composition was extracted from the workflow and run locally against the real `CHANGELOG.md`:

- `1.2.1` (stable): changelog section found, two pull lines (`:1.2.1`, `:latest`), no pre-release remark.
- `1.3.0-dev.2`: changelog section found, pull lines for `:1.3.0-dev.2` and `:dev`, plus the note that `:latest` still points at the last stable version.
- A version with no changelog entry falls back to "No CHANGELOG.md section for …".

The `gh release create/edit` flags used (`--prerelease=`, `--latest=`) are boolean flags that accept an explicit `=false`, which is what unmarks a release.

Not exercised end to end — that needs a real tag push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)