### PR TITLE
fix: put the whole version line into the release notes

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -117,26 +117,53 @@ jobs:
         run: |
           set -euo pipefail
 
-          # The section of CHANGELOG.md for exactly this version: everything
-          # between its "Version <x>" line and the next separator. An exact
-          # string compare rather than a pattern, so 1.3.0 cannot match the
-          # heading of 1.3.0-dev.2. The separator is matched as "starts with
-          # ---" rather than by a counted interval, which mawk, the awk on the
-          # runner, does not support.
-          NOTES="$(awk -v v="Version ${VERSION}" '
-            $0 == v { found = 1; next }
-            found && /^---/ { exit }
-            found { print }
+          # Every CHANGELOG.md section belonging to this release's version line,
+          # not just the one for this exact tag. A prerelease is one step of a
+          # version, so 1.3.0-dev.3 on its own would show the last step and
+          # hide the features that 1.3.0-dev.2 introduced; the stable 1.3.0
+          # would hide all of them. Sections are emitted newest first, the
+          # order they stand in the file.
+          #
+          # The separator is matched as "starts with ---" rather than by a
+          # counted interval, which mawk, the awk on the runner, does not
+          # support.
+          BASE="${VERSION%%-*}"
+          NOTES="$(awk -v base="${BASE}" '
+            /^Version / {
+              v = substr($0, 9)
+              if (open) { print "```"; open = 0 }
+              if (v == base || index(v, base "-") == 1) {
+                print ""
+                print "#### " v
+                print "```"
+                open = 1
+                blanks = 0
+              }
+              next
+            }
+            open && /^---/ { print "```"; open = 0; blanks = 0; next }
+            open {
+              # Hold blank lines back until a real line follows, so the blank
+              # line every section ends with does not sit inside the fence.
+              if ($0 ~ /^[ \t]*$/) { blanks++; next }
+              while (blanks-- > 0) print ""
+              blanks = 0
+              print
+            }
+            END { if (open) print "```" }
           ' CHANGELOG.md)"
 
           {
             if [[ -n "${NOTES//[[:space:]]/}" ]]; then
-              # Fenced, because the changelog is indented plain text: as
-              # markdown its deeper levels would collapse into code blocks
-              # halfway and read as a mess.
-              echo '```'
+              # Fenced per section, because the changelog is indented plain
+              # text: as markdown its deeper levels would collapse into code
+              # blocks halfway and read as a mess.
+              if [[ "${PRERELEASE}" == "true" ]]; then
+                echo "### Changes in ${BASE} so far"
+              else
+                echo "### Changes in ${BASE}"
+              fi
               printf '%s\n' "${NOTES}"
-              echo '```'
             else
               echo "No CHANGELOG.md section for ${VERSION}."
             fi

--- a/OPEN.md
+++ b/OPEN.md
@@ -139,10 +139,14 @@ One `case` decides all four columns, so the image tags and the release cannot
 disagree: whatever does not move `:latest` is a pre-release.
 
 The release is written after the image push, not before, because a release
-pointing at an image that never built sends people to a pull that fails. Its
-body is the section of `CHANGELOG.md` for exactly that version, so a release
-without a changelog entry says so instead of inventing notes. A re-run for a
-tag that already has a release edits it rather than failing.
+pointing at an image that never built sends people to a pull that fails. A
+re-run for a tag that already has a release edits it rather than failing.
+
+Its body is every `CHANGELOG.md` section on that version line, newest first,
+not only the one for the exact tag: a prerelease is one step of a version, so
+`v1.3.0-dev.3` alone would show the documentation work and hide the G-code
+tracking that `1.3.0-dev.2` introduced, and the stable `v1.3.0` would hide all
+of it. A version with no section at all says so instead of inventing notes.
 
 Publishing from a branch is rejected outright, so the "Run workflow" button can
 no longer overwrite `:latest` with whatever is on `main`.


### PR DESCRIPTION
Fallout from the first real tag, [v1.3.0-dev.3](https://github.com/Rdiger-36/bambulab-ams-spoolman-filamentstatus/releases/tag/v1.3.0-dev.3): the notes carried only the `CHANGELOG.md` section for the exact tag, which is the documentation work. Everything 1.3.0 actually is — G-code tracking, the settings page, manual spool assignment, the log rotation — landed in `1.3.0-dev.2` and was nowhere in the release.

A prerelease is one step of a version, not a version of its own, so the notes now collect **every section on that version line, newest first**, each under its own heading:

- `v1.3.0-dev.3` → `### Changes in 1.3.0 so far`, then `#### 1.3.0-dev.3` and `#### 1.3.0-dev.2`.
- A future `v1.3.0` → `### Changes in 1.3.0`, then its own section plus both prereleases. Without this the stable release would have hidden all of it.
- `v1.2.1` → unchanged, it has no prereleases.

The `-` in the prefix test keeps `1.2.1` from picking up a `1.2.10`.

Also: blank lines are held back until a real line follows, so the empty line every changelog section ends with no longer sits inside the fence.

## Verified

The notes composition was extracted from the workflow and run against the real `CHANGELOG.md` for `1.3.0-dev.3` (two sections, correct order), `1.3.0` (three sections) and `1.2.1` (one section, no change from before).

The already published `v1.3.0-dev.3` release gets its body updated separately — it does not need a rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)