### PR TITLE
fix: read AMS slot occupancy and the remaining amount from what the printer actually reports

### DIFF
--- a/public/frontend.js
+++ b/public/frontend.js
@@ -16,6 +16,9 @@ let currentPrinterName = "";
 // suffix "-S") is measured relative to its actual spool size already.
 function correctRemainIntJS(remainOn1kgBasis, trayWeight, trayType) {
 	const remain = parseFloat(remainOn1kgBasis);
+	// Mirrors correctRemainInt in src/ams.js: the AMS reports no percentage for
+	// the first seconds after a spool goes in, and null must not become 0.
+	if (!Number.isFinite(remain)) return null;
 	const weight = parseFloat(trayWeight);
 	const isSupportMaterial = typeof trayType === "string" && trayType.endsWith("-S");
 
@@ -843,7 +846,9 @@ document.addEventListener("DOMContentLoaded", () => {
 	    const tr = document.createElement("tr");
 	    tr.setAttribute("data-amsid", amsSpool.amsId);
 	
-	    let amsSpoolRemainingWeight = amsSpool.correctedWeight ?? ((amsSpool.slot.tray_weight / 100) * amsSpool.slot.remain);
+	    let amsSpoolRemainingWeight = amsSpool.correctedWeight ?? (amsSpool.slot.remain == null
+	        ? null
+	        : (amsSpool.slot.tray_weight / 100) * amsSpool.slot.remain);
 	    let correctedRemain = amsSpool.correctedRemain ?? amsSpool.slot.remain;
 	    let totalWeight = amsSpool.slot.tray_weight;
 
@@ -865,7 +870,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
 	    tr.innerHTML = `
 	        <td data-label="Spool" style="text-align:left">${spoolIdentityHtml(amsSpool, ctx)}</td>
-	        <td data-label="Remaining">${amsSpoolRemainingWeight} g / ${totalWeight} g (${correctedRemain}%)</td>
+	        <td data-label="Remaining">${amsSpoolRemainingWeight == null ? "—" : `${amsSpoolRemainingWeight} g`} / ${totalWeight} g (${correctedRemain == null ? "—" : `${correctedRemain}%`})</td>
 	        <td data-label="Serialnumber">${amsSpool.slot.tray_uuid ?? "—"}</td>
 	        <td data-label="State">${setIcon(amsSpool.error, amsSpool.slotState)}</td>
 	    `;
@@ -1210,7 +1215,9 @@ document.addEventListener("DOMContentLoaded", () => {
                 </table>
             `;
         } else if (button.textContent === "Merge Spool") {
-            let remain = (amsSpool.slot.remain / 100) * amsSpool.slot.tray_weight;
+            const remain = amsSpool.slot.remain == null
+                ? null
+                : (amsSpool.slot.remain / 100) * amsSpool.slot.tray_weight;
 
             return `
                 <p>Do you really want to merge this Spool with an existing Spool in Spoolman?</p>
@@ -1221,7 +1228,7 @@ document.addEventListener("DOMContentLoaded", () => {
                     </tr>
                     <tr>
                         <th>Spoolman Spool:</th>
-                        <td>Spool-ID ${amsSpool.mergeableSpool.id} - Bambu Lab - ${amsSpool.mergeableSpool.filament.material} - ${amsSpool.mergeableSpool.filament.name} - ${remain} g left on spool</td>
+                        <td>Spool-ID ${amsSpool.mergeableSpool.id} - Bambu Lab - ${amsSpool.mergeableSpool.filament.material} - ${amsSpool.mergeableSpool.filament.name} - ${remain == null ? "unknown" : `${remain} g`} left on spool</td>
                     </tr>
                 </table>
             `;

--- a/public/frontend.js
+++ b/public/frontend.js
@@ -1191,11 +1191,19 @@ document.addEventListener("DOMContentLoaded", () => {
             "Create Filament & Spool": "Create Filament & Spool",
             "Assign Spool": "Assign Spool",
             "Unassign Spool": "Unassign Spool",
-            "Show Info!": "Show Info!"
+            "Show Info!": "Show Info!",
+            // Not an action: the AMS has not reported the remaining percentage
+            // yet, and creating a spool without it would store a partly used
+            // one as brand new. The backend offers the real action as soon as
+            // the reading arrives, or after five updates without one.
+            "Waiting for data": "Waiting for data"
         };
 
         button.textContent = actionMap[amsSpool.option] || "No actions available";
         button.disabled = amsSpool.enableButton !== "true" || !spoolmanConnected;
+        if (amsSpool.option === "Waiting for data") {
+            button.title = "The AMS has not reported how much filament is left yet. Creating the spool now would store it as brand new.";
+        }
     }
 
     // Generate the content of the confirmation dialog

--- a/public/frontend.js
+++ b/public/frontend.js
@@ -805,7 +805,10 @@ document.addEventListener("DOMContentLoaded", () => {
 	        fil?.material     ?? slot.tray_type,
 	        fil?.name         ?? amsSpool.matchingExternalFilament?.name ?? slot.tray_sub_brands,
 	    ].filter(Boolean);
-	    const readable = isEmpty ? "Empty slot" : (nameParts.length ? nameParts.join(" · ") : "Unknown filament");
+	    // An empty slot the AMS is busy with is a spool going in or out, which
+	    // reports nothing the backend could tell from a truly empty slot.
+	    const emptyLabel = amsSpool.option === "Waiting for data" ? "Reading spool" : "Empty slot";
+	    const readable = isEmpty ? emptyLabel : (nameParts.length ? nameParts.join(" · ") : "Unknown filament");
 
 	    const color = (!isEmpty && slot.tray_color)
 	        ? `<span class="gc-swatch" style="background:#${normColorJS(slot.tray_color)}"></span>`

--- a/public/frontend.js
+++ b/public/frontend.js
@@ -866,7 +866,7 @@ document.addEventListener("DOMContentLoaded", () => {
 	    tr.innerHTML = `
 	        <td data-label="Spool" style="text-align:left">${spoolIdentityHtml(amsSpool, ctx)}</td>
 	        <td data-label="Remaining">${amsSpoolRemainingWeight} g / ${totalWeight} g (${correctedRemain}%)</td>
-	        <td data-label="Serialnumber">${amsSpool.slot.tray_uuid}</td>
+	        <td data-label="Serialnumber">${amsSpool.slot.tray_uuid ?? "—"}</td>
 	        <td data-label="State">${setIcon(amsSpool.error, amsSpool.slotState)}</td>
 	    `;
 	    const tdBtn = document.createElement("td");

--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -91,9 +91,14 @@ reprocessing.
   any spool whose `tray_weight != 1000`.
 - **`state.lastSpoolData === null` means "not yet seeded".** `[]` is a legitimate
   value (empty Spoolman) and must stay comparable. Never re-seed on empty.
-- **An unidentified spool looks exactly like an empty slot** in every field
-  except `state`. `slotIsOccupied()` is the only correct test; a slot with
-  `tray_uuid === "N/A"` is not automatically empty.
+- **An unidentified spool is not an empty slot.** `slotIsOccupied()` is the only
+  correct test; a slot with `tray_uuid === "N/A"` is not automatically empty.
+  It reads the shape of the tray record, because a loaded slot carries the full
+  payload (`tray_info_idx`, `tray_type`, `cols`, `tag_uid`) whether the chip was
+  read or not, while an empty one carries `id` and `state` alone. Never go back
+  to reading `state`: on a P2S it is 9 or 10 when empty and 11 or 27 when
+  loaded, so "non zero means occupied" marks every empty slot as a 3rd party
+  spool and freezes change detection for chipless slots.
 - **Manual assignment is a G-code mode feature.** `legacyMode()` gates it in
   three places: the 3rd party branch and the Bambu fallback in `processSlot`,
   and `rejectInLegacyMode()` on the mutating routes. A new entry point has to

--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -89,6 +89,15 @@ reprocessing.
   next MQTT message in `extractComparableTrayData()`; normalise into a local
   (`correctRemainInt`) instead. Mutating it desyncs change detection forever for
   any spool whose `tray_weight != 1000`.
+- **A `remain` of `null` means "not reported", never "empty".** The AMS answers
+  `-1` for the 15 to 20 seconds between a spool going in and its RFID
+  percentage arriving, and forever for a chipless one. `processData()` turns
+  that into `null` and `correctRemainInt()` passes the `null` through, so every
+  caller has to decide for itself: create the spool full, skip the legacy PATCH,
+  skip the weight test when looking for a mergeable spool, render a dash. A `0`
+  is a reading and means the spool really is empty. Collapsing the two created
+  new spools at `used_weight = initial_weight`, and in G-code mode nothing
+  patches the weight afterwards, so they stayed at 0 g left.
 - **`state.lastSpoolData === null` means "not yet seeded".** `[]` is a legitimate
   value (empty Spoolman) and must stay comparable. Never re-seed on empty.
 - **An unidentified spool is not an empty slot.** `slotIsOccupied()` is the only

--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -149,7 +149,13 @@ covers exactly this seam.
 `broadcastSSE()` for status/refresh events. A slot goes out through
 `toClientSpool()` in `uispool.js`, the one projection from the runtime object to
 the client payload, shared with `/api/spools` and `/api/print`. Add a field
-there when the UI needs it; anything not listed stays on the server.
+there when the UI needs it; anything not listed stays on the server. That
+includes the `"N/A"` placeholder `processData()` writes: it is a backend marker
+and the projection turns it back into `null`, so a client never renders it. The
+broadcast decision is `hasSpoolUiChanged()` alone, which compares that same
+projection. Do not add a second condition in front of it; the one that used to
+be there held every slot the printer could not identify back, so an emptied slot
+never reached the UI.
 
 **Changing slot classification:** `processSlot()` in `mqtt.js` branches, in
 order: invalid slot → empty slot → 3rd party (unidentified) → Bambu Lab. The

--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -111,7 +111,14 @@ build their Spoolman payload from.
   read or not, while an empty one carries `id` and `state` alone. Never go back
   to reading `state`: on a P2S it is 9 or 10 when empty and 11 or 27 when
   loaded, so "non zero means occupied" marks every empty slot as a 3rd party
-  spool and freezes change detection for chipless slots.
+  spool and freezes change detection for chipless slots. `slotIsBusy()` is the
+  one remaining reader of `state`, and it decides a label and nothing else: a
+  slot the AMS is moving filament into reports `{ id, state }` and nothing else,
+  which is byte for byte an empty slot, so for the roughly 20 seconds until the
+  tray record arrives the dashboard would call it empty with the user watching
+  the spool sit in it. Its allow list holds the values seen while busy, not the
+  ones seen at rest, so an unseen value reads as empty rather than leaving a
+  slot claiming to read a spool for good.
 - **A spool is not created before the AMS reports how much is left.**
   `usedWeightFromSlot()` turns the percentage into `used_weight`, and without
   one it has to assume brand new, which is wrong for a partly used spool that

--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -112,6 +112,16 @@ build their Spoolman payload from.
   to reading `state`: on a P2S it is 9 or 10 when empty and 11 or 27 when
   loaded, so "non zero means occupied" marks every empty slot as a 3rd party
   spool and freezes change detection for chipless slots.
+- **A spool is not created before the AMS reports how much is left.**
+  `usedWeightFromSlot()` turns the percentage into `used_weight`, and without
+  one it has to assume brand new, which is wrong for a partly used spool that
+  nothing corrects afterwards in G-code mode. `waitedLongEnoughForRemain()`
+  holds the create branch back, in both modes: automatic skips the slot for
+  this update, manual shows a disabled "Waiting for data" button. It gives up
+  after `MAX_REMAIN_WAITS` updates so a chip that never reports still gets its
+  spool. Merging is deliberately not held back, it writes only the tag. The
+  wait resolves itself because `hasTrayDataChanged()` treats the arrival of the
+  first reading as a change.
 - **Manual assignment is a G-code mode feature.** `legacyMode()` gates it in
   three places: the 3rd party branch and the Bambu fallback in `processSlot`,
   and `rejectInLegacyMode()` on the mutating routes. A new entry point has to

--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -50,9 +50,12 @@ Legacy mode also has no 3rd party support and no manual assignment. Both exist
 only to serve the G-code booking, which does not run here, so a chipless slot is
 read-only and the mapping endpoints answer 409.
 
-Consequence: in G-code mode the `remain` field is deliberately stripped before
-change detection, so a drifting RFID percentage does not trigger endless
-reprocessing.
+Consequence: in G-code mode the `remain` value is deliberately dropped before
+change detection (`hasTrayDataChanged()`), so a drifting RFID percentage does
+not trigger endless reprocessing. Whether there is a reading at all is kept:
+the transition from "not reported" to a real percentage has to refresh
+`printer.spoolData`, because that is the snapshot the create and merge actions
+build their Spoolman payload from.
 
 ## Contracts & invariants
 
@@ -90,8 +93,9 @@ reprocessing.
   (`correctRemainInt`) instead. Mutating it desyncs change detection forever for
   any spool whose `tray_weight != 1000`.
 - **A `remain` of `null` means "not reported", never "empty".** The AMS answers
-  `-1` for the 15 to 20 seconds between a spool going in and its RFID
-  percentage arriving, and forever for a chipless one. `processData()` turns
+  `-1` between a spool going in and its RFID percentage arriving, measured on
+  a P2S at anything from 17 seconds to over a minute, and forever for a
+  chipless one. `processData()` turns
   that into `null` and `correctRemainInt()` passes the `null` through, so every
   caller has to decide for itself: create the spool full, skip the legacy PATCH,
   skip the weight test when looking for a mergeable spool, render a dash. A `0`

--- a/src/ams.js
+++ b/src/ams.js
@@ -80,6 +80,13 @@ export function extractComparableTrayData(amsArray) {
                     return {
                         id: t.id,
                         occupied: slotIsOccupied(t),
+                        // An empty slot and one the AMS is reading are the same
+                        // two fields, so without this the slot is not
+                        // reprocessed while the spool goes in and the "Reading
+                        // spool" label never reaches a client. It is a boolean,
+                        // so the states the AMS cycles through cost one update
+                        // between them, not one each.
+                        busy: slotIsBusy(t),
                         tray_type: t.tray_type ?? null,
                         tray_info_idx: t.tray_info_idx ?? null,
                         tray_color: t.tray_color,
@@ -222,6 +229,10 @@ const BUSY_EMPTY_STATES = new Set([1, 5, 17, 21]);
  * around 20 seconds from the spool going in to the first tray record, and for
  * that whole time the dashboard would otherwise call the slot empty while the
  * user is watching the spool sit in it.
+ *
+ * Compared by `extractComparableTrayData()`, so the slot is reprocessed when it
+ * starts and stops being busy. Without that the label would only ever reach a
+ * client when some other slot happened to change in the same update.
  *
  * Deliberately an allow list of values seen while busy, not of values seen at
  * rest. A value nobody has observed yet reads as "at rest", so the slot says

--- a/src/ams.js
+++ b/src/ams.js
@@ -1,4 +1,4 @@
-import { settings } from "./settings.js";
+import { settings, legacyMode } from "./settings.js";
 import { toClientSpool } from "./uispool.js";
 
 /**
@@ -11,9 +11,9 @@ import { toClientSpool } from "./uispool.js";
  * printer read no RFID chip and is treated the same as a missing one.
  *
  * `remain` becomes null when the printer does not know it. The AMS reports -1
- * for the first 15 to 20 seconds after a spool is inserted, while it has the
- * RFID tag but not yet the remaining percentage, and a chipless spool reports
- * -1 for good. That was clamped to 0, which is a real reading meaning "empty",
+ * after a spool is inserted, while it has the RFID tag but not yet the
+ * remaining percentage, measured on a P2S at anything from 17 seconds to over a
+ * minute, and a chipless spool reports -1 for good. That was clamped to 0, which is a real reading meaning "empty",
  * so a spool created inside that window was booked as fully used and came out
  * at 0 g left.
  *
@@ -97,6 +97,38 @@ export function extractComparableTrayData(amsArray) {
             })
             .sort((a, b) => a.id - b.id),
     })).sort((a, b) => a.id - b.id);
+}
+
+/**
+ * Whether the tray data changed in a way that should trigger reprocessing.
+ *
+ * Legacy mode compares the projections as they are: the remaining percentage is
+ * what it writes to Spoolman, so every tick of it matters.
+ *
+ * G-code mode takes the weight from the sliced file instead, so a drifting
+ * percentage there would mean endless reprocessing and log output for nothing.
+ * The value is dropped, but whether there is one at all is kept. The AMS
+ * answers -1, which `processData` turns into null, for anything from 17 seconds
+ * to well over a minute after a spool goes in, and that transition has to be
+ * noticed: `printer.spoolData` is the snapshot the create and merge actions
+ * build their Spoolman payload from, and while it still says "no reading" they
+ * fall back to creating a full spool. A spool inserted at 53 % and created from
+ * the UI was stored as untouched, because nothing had refreshed the snapshot
+ * between the insert and the click.
+ *
+ * @param {object[]} nextTrayData - output of extractComparableTrayData
+ * @param {object[]} lastTrayData - the same projection of the previous report
+ * @returns {boolean}
+ */
+export function hasTrayDataChanged(nextTrayData, lastTrayData) {
+    if (legacyMode()) return JSON.stringify(nextTrayData) !== JSON.stringify(lastTrayData);
+
+    const project = data => data.map(ams => ({
+        ...ams,
+        tray: ams.tray.map(({ remain, ...tray }) => ({ ...tray, remainKnown: remain != null })),
+    }));
+
+    return JSON.stringify(project(nextTrayData)) !== JSON.stringify(project(lastTrayData));
 }
 
 /**

--- a/src/ams.js
+++ b/src/ams.js
@@ -352,23 +352,6 @@ export async function haveSpoolDataChanged(spools, lastSpoolData) {
 }
 
 /**
- * Whether a slot is worth pushing to the UI over SSE.
- *
- * On the first run everything is sent, so the client starts from a complete
- * picture. Afterwards only slots the printer fully identified are sent, which
- * keeps the sparse payloads of empty and unidentified slots from overwriting a
- * populated row on every message.
- */
-export function shouldSendSlotUpdate(slot, isFirstRun) {
-    const isValidBambu =
-        slot &&
-        Object.keys(slot).length > 6 &&
-        slot.tray_uuid !== "N/A" &&
-        slot.tray_sub_brands !== "N/A";
-    return isFirstRun || isValidBambu;
-}
-
-/**
  * Whether anything the UI actually displays changed between two versions of a
  * slot, used to suppress redundant SSE broadcasts.
  *

--- a/src/ams.js
+++ b/src/ams.js
@@ -56,15 +56,26 @@ export function extractComparableTrayData(amsArray) {
         tray: ams.tray
             .filter(t => t && Object.keys(t).length > 6)
             .map(t => {
-                // A spool the printer cannot identify reports no uuid, material,
-                // colour or weight, so the only thing worth comparing is whether
-                // it is there at all. Dropping such trays entirely used to hide
-                // the arrival of a 3rd party spool from the change detection, so
-                // the slot was never reprocessed. `state` itself is deliberately
-                // not compared: it varies between loaded-but-unidentified values
-                // (10 and 20 both occur) and would cause pointless reprocessing.
+                // A spool the printer cannot identify carries no uuid and no
+                // material, but it does carry what the user set on the AMS, so
+                // that is compared alongside the bare occupancy. Occupancy alone
+                // was not enough: swapping one chipless spool for another, or
+                // setting material and colour on the printer, left the
+                // projection unchanged and the slot was never reprocessed.
+                //
+                // `state` is deliberately not compared. It is undocumented, it
+                // varies between reports about the same unchanged slot, and it
+                // does not separate an empty slot from a loaded one either;
+                // `slotIsOccupied` explains what replaced it.
                 if (t.tray_uuid === "N/A" || t.tray_sub_brands === "N/A") {
-                    return { id: t.id, occupied: slotIsOccupied(t) };
+                    return {
+                        id: t.id,
+                        occupied: slotIsOccupied(t),
+                        tray_type: t.tray_type ?? null,
+                        tray_info_idx: t.tray_info_idx ?? null,
+                        tray_color: t.tray_color,
+                        tray_weight: t.tray_weight,
+                    };
                 }
                 return {
                     id: t.id,
@@ -113,37 +124,42 @@ export function correctRemainInt(remainOn1kgBasis, trayWeight, trayType = null) 
 }
 
 /**
+ * The fields an empty AMS slot reports. Anything beyond these is filament data.
+ *
+ * The names are the ones left after `processData`, which fills `tray_color`,
+ * `tray_sub_brands`, `tray_weight` and `tray_uuid` with placeholders on every
+ * tray, so those four say nothing about occupancy.
+ */
+const EMPTY_TRAY_KEYS = new Set(["id", "state", "remain", "tray_color", "tray_sub_brands", "tray_weight", "tray_uuid"]);
+
+/**
  * Whether the AMS reports something physically sitting in the slot.
  *
- * A slot holding a spool the printer cannot identify, whether because it has
- * no RFID chip or because reading it failed, comes through with the same
- * sparse payload as an empty slot: tray_uuid "N/A", no tray_type,
- * tray_weight 0. The only field that separates them is `state`.
+ * Occupancy is read from the payload the tray carries, not from `state`.
  *
- * `state` is not documented by Bambu Lab, so what follows is what this project
- * has actually seen on a P2S, not a specification:
+ * A loaded slot always comes with the full tray record, whether the RFID chip
+ * was read or not: the AMS fills `tray_info_idx` (`GFL99` for anything it
+ * cannot identify), `tray_type`, `cols`, `tag_uid` and the temperature fields
+ * from its own defaults. An empty slot reports `id` and `state` and nothing
+ * else, which is the whole difference between the two.
  *
- * - `0` on an empty slot, in every observation so far.
- * - `3`, `10`, `11`, `20` and `27` while a slot is loaded. Which one appears
- *   varies, including between two reports about the same unchanged slot.
- * - `11` was once read as proof of a Bambu Lab tag having been decoded. It is
- *   not: a chipless spool with an all zero `tray_uuid` reports 11 as well, so
- *   the value says something is in the slot, not that it was identified. Use
- *   `tray_uuid` for that.
+ * `state` used to be the test and it is wrong. It is undocumented, and on a
+ * P2S with two AMS 2 Pro units it reads 9 or 10 on an empty slot and 11 or 27
+ * on a loaded one, so "non zero means occupied" marked every empty slot as
+ * holding an unidentifiable spool. That is what put an "N/A" row with an
+ * "Assign Spool" button on every emptied slot, and it also froze change
+ * detection: `extractComparableTrayData` reduces an unidentified tray to its
+ * occupancy, so with occupancy stuck at true, removing or inserting a chipless
+ * spool produced a byte identical projection and was never processed.
  *
- * Everything non zero is therefore treated as occupied, which is a heuristic in
- * both directions: a value nobody has seen yet still reads as occupied, and
- * firmware reporting a transient non zero state on an empty slot would show a
- * phantom spool until it settles. It is the safer way round, because the
- * opposite, an allow list of known values, would make a spool disappear from
- * the UI the first time a firmware update invents a new one.
- *
- * Firmware that does not report `state` at all falls back to "not occupied", so
- * such slots keep being treated as empty rather than sprouting phantom spools.
+ * The trade off runs the other way round now. Firmware that reports a loaded
+ * chipless slot with no filament fields at all would read as empty here, where
+ * the old heuristic invented a spool on every empty one. Nothing observed so
+ * far reports such a tray.
  */
 export function slotIsOccupied(slot) {
-    if (slot?.state === null || slot?.state === undefined) return false;
-    return Number(slot.state) !== 0;
+    if (!slot) return false;
+    return Object.keys(slot).some(key => !EMPTY_TRAY_KEYS.has(key));
 }
 
 /**

--- a/src/ams.js
+++ b/src/ams.js
@@ -8,8 +8,14 @@ import { toClientSpool } from "./uispool.js";
  *
  * Missing material, colour and uuid all become the literal "N/A", which is the
  * marker every later stage tests against. An all zero `tray_uuid` means the
- * printer read no RFID chip and is treated the same as a missing one. Negative
- * or missing `remain` is clamped to 0.
+ * printer read no RFID chip and is treated the same as a missing one.
+ *
+ * `remain` becomes null when the printer does not know it. The AMS reports -1
+ * for the first 15 to 20 seconds after a spool is inserted, while it has the
+ * RFID tag but not yet the remaining percentage, and a chipless spool reports
+ * -1 for good. That was clamped to 0, which is a real reading meaning "empty",
+ * so a spool created inside that window was booked as fully used and came out
+ * at 0 g left.
  *
  * PETG Translucent is a special case: it reports a fully transparent colour
  * that would render as invisible in the UI, so it is shown as white instead.
@@ -24,11 +30,14 @@ export function processData(amsData) {
             const isPetgTranslucent = slot.tray_sub_brands === "PETG Translucent" && slot.tray_color === "00000000";
             const updatedTrayColor = isPetgTranslucent ? "FFFFFF00" : (slot.tray_color ?? "N/A");
 
-            if (!slot.remain || slot.remain < 0) slot.remain = 0;
+            // Not written back onto `slot`: the raw value is what the next
+            // report is compared against, and mutating it here desyncs that.
+            const rawRemain = Number(slot.remain);
+            const remain = Number.isFinite(rawRemain) && rawRemain >= 0 ? rawRemain : null;
 
             return {
                 ...slot,
-                remain: slot.remain,
+                remain,
                 tray_color: updatedTrayColor,
                 tray_sub_brands: slot.tray_sub_brands === "" ? "N/A" : (slot.tray_sub_brands ?? "N/A"),
                 tray_weight: slot.tray_weight ?? 0,
@@ -101,10 +110,14 @@ export function extractComparableTrayData(amsArray) {
  * @param {number|string} remainOn1kgBasis - `remain` as reported by the AMS
  * @param {number|string} trayWeight - the spool's real filament weight in grams
  * @param {string|null} trayType - `tray_type`, needed to spot support material
- * @returns {number} remaining percentage of the real spool, rounded
+ * @returns {number|null} remaining percentage of the real spool, rounded, or
+ *   null when the printer reported no usable value
  */
 export function correctRemainInt(remainOn1kgBasis, trayWeight, trayType = null) {
     const remain = parseFloat(remainOn1kgBasis);
+    // Unknown in, unknown out. Every caller has to decide for itself what to do
+    // without a reading; none of them may treat it as 0.
+    if (!Number.isFinite(remain)) return null;
     const weight = parseFloat(trayWeight);
 
     // Support/accessory material (tray_type suffix "-S", e.g. "PLA-S") is sold
@@ -299,12 +312,16 @@ export function findMergeableSpool(amsSpool, allSpools) {
 
     return matchingSpools.find(spoolmanSpool => {
         const tag = (spoolmanSpool.extra?.tag || "").trim();
-        const spoolRemainingWeight = (amsSpool.remain / 100) * spoolmanSpool.initial_weight;
-        const lowerTolerance = spoolRemainingWeight * 0.85;
-        const upperTolerance = spoolRemainingWeight * 1.15;
-        const weightMatches =
-            spoolmanSpool.remaining_weight >= lowerTolerance &&
-            spoolmanSpool.remaining_weight <= upperTolerance;
+        // Without a remain reading there is nothing to compare the weight
+        // against. Treating the missing value as 0 matched every spool that
+        // happened to be empty, so the test is skipped instead and the
+        // remaining criteria decide on their own.
+        const spoolRemainingWeight = amsSpool.remain == null
+            ? null
+            : (amsSpool.remain / 100) * spoolmanSpool.initial_weight;
+        const weightMatches = spoolRemainingWeight !== null &&
+            spoolmanSpool.remaining_weight >= spoolRemainingWeight * 0.85 &&
+            spoolmanSpool.remaining_weight <= spoolRemainingWeight * 1.15;
         const hasTag = tag && tag !== "" && tag !== '""';
 
         if (settings.NEVER_MERGE_IF_TAG && hasTag) return false;

--- a/src/ams.js
+++ b/src/ams.js
@@ -207,6 +207,33 @@ export function slotIsOccupied(slot) {
     return Object.keys(slot).some(key => !EMPTY_TRAY_KEYS.has(key));
 }
 
+// The `state` values seen on a sparse tray while the AMS was moving filament in
+// or out of the slot, as opposed to 9 and 10, which it reports while a slot sits
+// there empty. Undocumented, so this is an observation on a P2S, not a
+// specification.
+const BUSY_EMPTY_STATES = new Set([1, 5, 17, 21]);
+
+/**
+ * Whether an empty looking slot is one the AMS is currently working on.
+ *
+ * Purely cosmetic, and the one place `state` is still read. It has to be: a
+ * spool being read reports `{ id, state }` and nothing else, byte for byte what
+ * an empty slot reports, so there is no field to tell them apart. The AMS takes
+ * around 20 seconds from the spool going in to the first tray record, and for
+ * that whole time the dashboard would otherwise call the slot empty while the
+ * user is watching the spool sit in it.
+ *
+ * Deliberately an allow list of values seen while busy, not of values seen at
+ * rest. A value nobody has observed yet reads as "at rest", so the slot says
+ * "Empty slot", which is what it says today. The other way round an empty slot
+ * could claim to be reading a spool for good. Nothing acts on this either way:
+ * occupancy comes from `slotIsOccupied()`, which does not look at `state`.
+ */
+export function slotIsBusy(slot) {
+    if (!slot || slotIsOccupied(slot)) return false;
+    return BUSY_EMPTY_STATES.has(Number(slot.state));
+}
+
 /**
  * Finds the Spoolman spool already connected to this slot.
  *

--- a/src/mqtt.js
+++ b/src/mqtt.js
@@ -467,8 +467,9 @@ async function processSlot(printer, ams, slot, spools, externalFilaments, intern
         return false;
     }
 
-    // An unidentified spool looks exactly like an empty slot in every field but
-    // `state`, so an occupied slot must not be swallowed by this branch.
+    // An unidentified spool shares every placeholder field with an empty slot,
+    // so an occupied slot must not be swallowed by this branch. Only
+    // `slotIsOccupied()` tells the two apart.
     if ((slot.tray_uuid === "N/A" || slot.tray_sub_brands === "N/A") && (slot.tray_weight === 0 || slot.tray_weight === "0") && (!slot.tray_type || slot.tray_type === "") && !slotIsOccupied(slot)) {
         console.debug(printer.name, printer.logFilePath, "No Data found in Slots (empty slot with N/A values)");
         const newUiSpool = buildEmptySpool(printer, amsId, slot);

--- a/src/mqtt.js
+++ b/src/mqtt.js
@@ -559,6 +559,14 @@ async function processSlot(printer, ams, slot, spools, externalFilaments, intern
                         break;
                     }
 
+                    // The whole mode rests on the percentage, so there is
+                    // nothing to patch until the AMS has read one. It arrives
+                    // within about 20 seconds of the spool going in.
+                    if (currRemain === null) {
+                        console.debug(printer.name, printer.logFilePath, " Remain not reported yet; skipping PATCH until the AMS has read it");
+                        break;
+                    }
+
                     const remainingWeight = Math.round((currRemain / 100) * slot.tray_weight);
                     const newLocation = settings.SET_LOCATION ? `${printer.name} - ${amsId}` : null;
 
@@ -601,7 +609,7 @@ async function processSlot(printer, ams, slot, spools, externalFilaments, intern
 
     if (!found) {
         console.debug(printer.name, printer.logFilePath, " Connected Spool not found, process with merging and creation logic");
-        console.log(printer.name, printer.logFilePath, ` [${amsId}] ${slot.tray_sub_brands} ${slot.tray_color} (${slot.remain}%) [[ ${slot.tray_uuid} ]]`);
+        console.log(printer.name, printer.logFilePath, ` [${amsId}] ${slot.tray_sub_brands} ${slot.tray_color} (${slot.remain == null ? "remain unknown" : `${slot.remain}%`}) [[ ${slot.tray_uuid} ]]`);
 
         mergeableSpool = spools.length !== 0 ? findMergeableSpool(slot, spools) : null;
 
@@ -673,8 +681,12 @@ async function processSlot(printer, ams, slot, spools, externalFilaments, intern
         }
     }
 
+    // Both stay null while the AMS has not reported a percentage yet, so the
+    // dashboard shows a dash instead of a confident "0 g".
     const correctedRemain = correctRemainInt(slot.remain, slot.tray_weight, slot.tray_type);
-    const correctedWeight = Math.round((correctedRemain / 100) * slot.tray_weight);
+    const correctedWeight = correctedRemain === null
+        ? null
+        : Math.round((correctedRemain / 100) * slot.tray_weight);
 
     // A manual assignment wins over the automatic tag match: it is the only way
     // for the user to resolve two tagged spools that are identical in

--- a/src/mqtt.js
+++ b/src/mqtt.js
@@ -481,9 +481,12 @@ async function processSlot(printer, ams, slot, spools, externalFilaments, intern
     // only sign of life is `state`, which the empty branch above no longer takes.
     if (slot.tray_uuid === "N/A" || slot.tray_sub_brands === "N/A") {
         console.debug(printer.name, printer.logFilePath, "Slot is read-only (3rd party spool)");
-        // The printer may know the material because the user set it on the AMS;
-        // when it does not, leave the placeholder rather than blanking the field.
-        if (slot.tray_type) slot.tray_sub_brands = slot.tray_type;
+        // `tray_sub_brands` used to be overwritten with the material here, so
+        // the slot had a name at all. The projection now drops the "N/A"
+        // placeholder on its own, and the dashboard builds the name from the
+        // material anyway, so copying it produced "PLA . PLA". It also wrote
+        // into the record kept as `printer.lastAmsData`, which is the baseline
+        // the next report is compared against.
 
         // No RFID chip means no extra.tag link in Spoolman, so the only way to
         // know which spool sits here is a manual assignment made in the UI.
@@ -499,7 +502,7 @@ async function processSlot(printer, ams, slot, spools, externalFilaments, intern
             // material and colour set on the printer, and the assignment that
             // decides whether consumption can be booked onto it.
             const assignment = mappedSpool ? `=> Spool-ID ${mappedSpool.id} (assigned)` : "(3rd party, not assigned)";
-            console.log(printer.name, printer.logFilePath, ` [${amsId}] ${slot.tray_sub_brands} ${slot.tray_color} ${assignment}`);
+            console.log(printer.name, printer.logFilePath, ` [${amsId}] ${slot.tray_type || "Unknown material"} ${slot.tray_color} ${assignment}`);
         }
         printer.spoolData.push(newUiSpool);
         return false;

--- a/src/mqtt.js
+++ b/src/mqtt.js
@@ -422,6 +422,47 @@ async function clearLocationIfSpoolChanged(printer, amsId, currentSpoolId, prevB
     }
 }
 
+// How many AMS updates a slot may wait for its remain reading before a spool is
+// created without one. The reading arrived between 17 and 74 seconds after the
+// spool went in across every insert captured on a P2S, so at the default 15
+// second interval five updates cover that with room to spare, and a spool whose
+// chip never reports still ends up in Spoolman rather than being skipped in
+// silence.
+const MAX_REMAIN_WAITS = 5;
+
+/**
+ * Whether a slot has waited long enough to be created without a remain reading.
+ *
+ * Counts consecutive AMS updates in which the printer reported no percentage
+ * for this slot. The count is kept per slot and reset as soon as a reading
+ * arrives or a different spool shows up, so it measures this spool in this
+ * slot and nothing else.
+ *
+ * Creating without a reading is not free: `usedWeightFromSlot()` then treats
+ * the spool as brand new, which is wrong for a partly used one. Waiting is the
+ * better default, giving up eventually is better than never creating the spool
+ * at all.
+ *
+ * @param {object} printer - the printer runtime object, holding the counters
+ * @param {string} amsId - the slot label
+ * @param {object} slot - the normalised slot
+ * @returns {boolean} true once the wait is over, so the caller stops holding back
+ */
+export function waitedLongEnoughForRemain(printer, amsId, slot) {
+    if (!printer.remainWaits) printer.remainWaits = {};
+
+    if (slot.remain != null) {
+        delete printer.remainWaits[amsId];
+        return true;
+    }
+
+    const previous = printer.remainWaits[amsId];
+    const waits = previous?.uuid === slot.tray_uuid ? previous.waits + 1 : 1;
+    printer.remainWaits[amsId] = { uuid: slot.tray_uuid, waits };
+
+    return waits > MAX_REMAIN_WAITS;
+}
+
 /**
  * Classifies one AMS slot, acts on it in Spoolman, and records the result for
  * the UI.
@@ -611,7 +652,19 @@ async function processSlot(printer, ams, slot, spools, externalFilaments, intern
         if (!mergeableSpool) {
             existingSpool = spools.length !== 0 ? findExistingSpool(slot, spools) : null;
 
-            if (!existingSpool) {
+            // Creating a spool writes its used weight, and that comes from the
+            // AMS remain percentage, which is not there for the first seconds
+            // after a spool goes in. Creating in that window stores a brand new
+            // spool for a partly used one, and in G-code mode nothing corrects
+            // the weight afterwards. Merging is deliberately not held back: it
+            // only writes the tag, never a weight.
+            const waitingForRemain = !existingSpool && !waitedLongEnoughForRemain(printer, amsId, slot);
+
+            if (!existingSpool && waitingForRemain) {
+                console.debug(printer.name, printer.logFilePath, "    Waiting for the AMS to report the remaining percentage before creating a spool");
+                option = "Waiting for data";
+                enableButton = "false";
+            } else if (!existingSpool) {
                 if (matchingInternalFilament) {
                     console.log(printer.name, printer.logFilePath, "    Filament exists, create a Spool with this Data");
                     console.log(printer.name, printer.logFilePath, `    Material: ${matchingInternalFilament.material}, Color: ${matchingInternalFilament.name}`);
@@ -654,7 +707,7 @@ async function processSlot(printer, ams, slot, spools, externalFilaments, intern
             option = "Merge Spool";
         }
 
-        if (!automatic) enableButton = "true";
+        if (!automatic && option !== "Waiting for data") enableButton = "true";
         printer.lastUpdateTime = new Date();
 
         // A create/merge just happened, so look the spool back up right away so

--- a/src/mqtt.js
+++ b/src/mqtt.js
@@ -29,7 +29,6 @@ import {
     findMatchingInternalFilament,
     findMergeableSpool,
     haveSpoolDataChanged,
-    shouldSendSlotUpdate,
     hasSpoolUiChanged,
 } from "./ams.js";
 import { toClientSpool } from "./uispool.js";
@@ -463,7 +462,7 @@ async function processSlot(printer, ams, slot, spools, externalFilaments, intern
         console.debug(printer.name, printer.logFilePath, "No Data found in Slots");
         const newUiSpool = buildEmptySpool(printer, amsId, slot);
         await clearLocationIfSpoolChanged(printer, amsId, null, prevByAmsId);
-        pushSlotUpdate(printer, newUiSpool, prevByAmsId, slot);
+        pushSlotUpdate(printer, newUiSpool, prevByAmsId);
         return false;
     }
 
@@ -474,7 +473,7 @@ async function processSlot(printer, ams, slot, spools, externalFilaments, intern
         console.debug(printer.name, printer.logFilePath, "No Data found in Slots (empty slot with N/A values)");
         const newUiSpool = buildEmptySpool(printer, amsId, slot);
         await clearLocationIfSpoolChanged(printer, amsId, null, prevByAmsId);
-        pushSlotUpdate(printer, newUiSpool, prevByAmsId, slot);
+        pushSlotUpdate(printer, newUiSpool, prevByAmsId);
         return false;
     }
 
@@ -494,9 +493,13 @@ async function processSlot(printer, ams, slot, spools, externalFilaments, intern
         const mappedSpool = legacyMode() ? null : resolveMappedSpool(printer, amsId, slot, spools);
         const newUiSpool = buildThirdPartySpool(printer, amsId, slot, mappedSpool);
         await clearLocationIfSpoolChanged(printer, amsId, mappedSpool?.id ?? null, prevByAmsId);
-        if (shouldSendSlotUpdate(slot, printer.first_run) && hasSpoolUiChanged(newUiSpool, prevByAmsId[newUiSpool.amsId])) {
+        if (hasSpoolUiChanged(newUiSpool, prevByAmsId[newUiSpool.amsId])) {
             broadcastSlotUpdate(printer.id, newUiSpool);
-            console.log(printer.name, printer.logFilePath, ` [${amsId}] ${slot.tray_type} ${slot.tray_color} [[ ${slot.tray_uuid} ]]`);
+            // No uuid to print, so the line says what the slot is instead: the
+            // material and colour set on the printer, and the assignment that
+            // decides whether consumption can be booked onto it.
+            const assignment = mappedSpool ? `=> Spool-ID ${mappedSpool.id} (assigned)` : "(3rd party, not assigned)";
+            console.log(printer.name, printer.logFilePath, ` [${amsId}] ${slot.tray_sub_brands} ${slot.tray_color} ${assignment}`);
         }
         printer.spoolData.push(newUiSpool);
         return false;
@@ -714,7 +717,7 @@ async function processSlot(printer, ams, slot, spools, externalFilaments, intern
         correctedWeight,
     };
 
-    pushSlotUpdate(printer, newUiSpool, prevByAmsId, slot);
+    pushSlotUpdate(printer, newUiSpool, prevByAmsId);
     return mutated;
 }
 
@@ -790,11 +793,19 @@ function resolveMappedSpool(printer, amsId, slot, spools) {
 }
 
 /**
- * Records a UI spool for this AMS update and broadcasts it, but only when the
- * slot is worth sending and something the user sees actually changed.
+ * Records a UI spool for this AMS update and broadcasts it, but only when
+ * something the user sees actually changed.
+ *
+ * A slot with no previous entry counts as changed, so the first pass sends
+ * everything. There used to be a second condition, holding back every slot the
+ * printer had not fully identified, which meant an emptied slot never reached
+ * the UI and its row kept showing the spool that had been taken out. It was
+ * guarding against sparse payloads overwriting a populated row, which was the
+ * old occupancy bug rather than a real case, and `hasSpoolUiChanged` already
+ * suppresses everything that would not change the display.
  */
-function pushSlotUpdate(printer, newUiSpool, prevByAmsId, slot) {
-    if (shouldSendSlotUpdate(slot, printer.first_run) && hasSpoolUiChanged(newUiSpool, prevByAmsId[newUiSpool.amsId])) {
+function pushSlotUpdate(printer, newUiSpool, prevByAmsId) {
+    if (hasSpoolUiChanged(newUiSpool, prevByAmsId[newUiSpool.amsId])) {
         broadcastSlotUpdate(printer.id, newUiSpool);
     }
     printer.spoolData.push(newUiSpool);

--- a/src/mqtt.js
+++ b/src/mqtt.js
@@ -661,7 +661,11 @@ async function processSlot(printer, ams, slot, spools, externalFilaments, intern
             const waitingForRemain = !existingSpool && !waitedLongEnoughForRemain(printer, amsId, slot);
 
             if (!existingSpool && waitingForRemain) {
-                console.debug(printer.name, printer.logFilePath, "    Waiting for the AMS to report the remaining percentage before creating a spool");
+                // Logged rather than debugged, and in both modes: in automatic
+                // nobody is looking at the button, so without this line the
+                // service just appears to ignore the slot for a minute.
+                const waits = printer.remainWaits?.[amsId]?.waits ?? 0;
+                console.log(printer.name, printer.logFilePath, `    Waiting for the AMS to report how much is left before creating a spool (${waits}/${MAX_REMAIN_WAITS})`);
                 option = "Waiting for data";
                 enableButton = "false";
             } else if (!existingSpool) {

--- a/src/mqtt.js
+++ b/src/mqtt.js
@@ -24,6 +24,7 @@ import {
     extractComparableTrayData,
     correctRemainInt,
     slotIsOccupied,
+    slotIsBusy,
     findExistingSpool,
     findMatchingExternalFilament,
     findMatchingInternalFilament,
@@ -788,7 +789,13 @@ async function processSlot(printer, ams, slot, spools, externalFilaments, intern
     return mutated;
 }
 
-/** Builds the UI entry for an empty slot: nothing matched, no action offered. */
+/**
+ * Builds the UI entry for an empty slot: nothing matched, no action offered.
+ *
+ * A slot the AMS is currently reading looks exactly like an empty one until the
+ * tray record arrives, so it is still built here, but it says "Waiting for
+ * data" rather than claiming there is nothing to do. See `slotIsBusy()`.
+ */
 function buildEmptySpool(printer, amsId, slot) {
     return {
         amsId,
@@ -797,7 +804,7 @@ function buildEmptySpool(printer, amsId, slot) {
         matchingInternalFilament: null,
         matchingExternalFilament: null,
         existingSpool: null,
-        option: "No actions available",
+        option: slotIsBusy(slot) ? "Waiting for data" : "No actions available",
         enableButton: "false",
         printerName: printer.name,
         logFilePath: printer.logFilePath,

--- a/src/mqtt.js
+++ b/src/mqtt.js
@@ -29,6 +29,7 @@ import {
     findMatchingInternalFilament,
     findMergeableSpool,
     haveSpoolDataChanged,
+    hasTrayDataChanged,
     hasSpoolUiChanged,
 } from "./ams.js";
 import { toClientSpool } from "./uispool.js";
@@ -322,13 +323,7 @@ async function handleMqttMessage(printer, topic, message) {
                         const processedAmsData = processData(data.print.ams.ams);
                         const newTrayData = extractComparableTrayData(processedAmsData);
                         const lastTrayData = extractComparableTrayData(printer.lastAmsData || []);
-                        // In G-code mode the AMS remain % is irrelevant (weight is
-                        // tracked from the slice), so don't let it trigger reprocessing
-                        // and log output. Only react to real identity/weight changes.
-                        const stripRemain = (d) => legacyMode() ? d
-                            : d.map(a => ({ ...a, tray: a.tray.map(({ remain, ...t }) => t) }));
-                        const trayDataChanged =
-                            JSON.stringify(stripRemain(newTrayData)) !== JSON.stringify(stripRemain(lastTrayData));
+                        const trayDataChanged = hasTrayDataChanged(newTrayData, lastTrayData);
 
                         if (isValidAmsData && (spoolsChanged || trayDataChanged)) {
                             console.debug(printer.name, printer.logFilePath, "Loaded AMS Spools:");

--- a/src/printers.js
+++ b/src/printers.js
@@ -47,6 +47,9 @@ function createRuntimePrinter(entry) {
         currentLayerNum: 0,
         consumptionBooked: false,
         sliceFetchDone: false,
+        // How many AMS updates a slot has been waiting for its remain reading,
+        // keyed by slot label. See waitedLongEnoughForRemain() in mqtt.js.
+        remainWaits: {},
     };
 }
 

--- a/src/spoolman.js
+++ b/src/spoolman.js
@@ -12,12 +12,18 @@ import { correctRemainInt } from "./ams.js";
  * if they were brand new. Otherwise a spool found at e.g. 32% remaining would
  * be created at 100% (used_weight 0) and immediately drift out of sync.
  *
+ * No reading means brand new. For the first 15 to 20 seconds after a spool is
+ * inserted the AMS knows the tag but not the percentage, and a spool created
+ * in that window used to be booked as fully used, ending up at 0 g left with
+ * nothing in G-code mode to correct it afterwards. Starting such a spool full
+ * is the recoverable direction: a print books what it consumes.
+ *
  * @param {object} slot - a normalised AMS slot
  * @returns {number} grams already consumed, never negative
  */
 function usedWeightFromSlot(slot) {
     const remainPct = correctRemainInt(slot.remain, slot.tray_weight, slot.tray_type);
-    if (!Number.isFinite(remainPct)) return 0;
+    if (remainPct === null || !Number.isFinite(remainPct)) return 0;
     const remainingWeight = Math.round((remainPct / 100) * slot.tray_weight);
     return Math.max(0, Math.round(slot.tray_weight - remainingWeight));
 }

--- a/src/spoolman.js
+++ b/src/spoolman.js
@@ -12,10 +12,10 @@ import { correctRemainInt } from "./ams.js";
  * if they were brand new. Otherwise a spool found at e.g. 32% remaining would
  * be created at 100% (used_weight 0) and immediately drift out of sync.
  *
- * No reading means brand new. For the first 15 to 20 seconds after a spool is
- * inserted the AMS knows the tag but not the percentage, and a spool created
- * in that window used to be booked as fully used, ending up at 0 g left with
- * nothing in G-code mode to correct it afterwards. Starting such a spool full
+ * No reading means brand new. For up to a minute after a spool is inserted the
+ * AMS knows the tag but not the percentage, and a spool created in that window
+ * used to be booked as fully used, ending up at 0 g left with nothing in G-code
+ * mode to correct it afterwards. Starting such a spool full
  * is the recoverable direction: a print books what it consumes.
  *
  * @param {object} slot - a normalised AMS slot

--- a/src/uispool.js
+++ b/src/uispool.js
@@ -16,15 +16,29 @@ import { consumptionKey } from "./gcode.js";
  * the projection itself instead of a hand-maintained key list.
  */
 
+/**
+ * Turns the "N/A" placeholder into a real absence.
+ *
+ * `processData` writes that literal into every field the printer left out,
+ * because the backend branches on it. It is a marker, not a value, and it must
+ * not leave the server: a client that receives it renders it, which is how an
+ * emptied slot came to be labelled "N/A" and how its colour swatch ended up
+ * styled `#N/A`. An empty string is squashed for the same reason.
+ */
+function orNull(value) {
+    if (value === "N/A" || value === "") return null;
+    return value ?? null;
+}
+
 /** The AMS slot fields the Web UI reads. Everything else stays on the server. */
 function pickSlot(slot) {
     if (!slot) return null;
     return {
-        tray_uuid: slot.tray_uuid ?? null,
-        tray_type: slot.tray_type ?? null,
-        tray_sub_brands: slot.tray_sub_brands ?? null,
-        tray_color: slot.tray_color ?? null,
-        tray_info_idx: slot.tray_info_idx ?? null,
+        tray_uuid: orNull(slot.tray_uuid),
+        tray_type: orNull(slot.tray_type),
+        tray_sub_brands: orNull(slot.tray_sub_brands),
+        tray_color: orNull(slot.tray_color),
+        tray_info_idx: orNull(slot.tray_info_idx),
         tray_weight: slot.tray_weight ?? null,
         remain: slot.remain ?? null,
     };
@@ -80,7 +94,9 @@ function pickInternalFilament(filament) {
  * @returns {object} the payload for `/api/spools`, `/api/print` and SSE
  */
 export function toClientSpool(uiSpool) {
-    const slot = uiSpool.slot || {};
+    // Derived below from the picked slot, not the runtime one, so the "N/A"
+    // placeholder cannot slip back in through a fallback.
+    const slot = pickSlot(uiSpool.slot || {});
     const existingSpool = pickSpool(uiSpool.existingSpool);
     const matchingExternalFilament = pickExternalFilament(uiSpool.matchingExternalFilament);
     const filament = existingSpool?.filament || null;
@@ -88,7 +104,7 @@ export function toClientSpool(uiSpool) {
     return {
         amsId: uiSpool.amsId ?? null,
         slotState: uiSpool.slotState ?? null,
-        slot: pickSlot(slot),
+        slot,
         existingSpool,
         mergeableSpool: pickSpool(uiSpool.mergeableSpool),
         matchingInternalFilament: pickInternalFilament(uiSpool.matchingInternalFilament),

--- a/test/ams.test.js
+++ b/test/ams.test.js
@@ -256,3 +256,22 @@ test("slotIsBusy never fires on a slot that actually holds something", () => {
     assert.equal(slotIsBusy({ ...thirdParty, state: 17 }), false);
     assert.equal(slotIsBusy({ ...bambuTray, state: 5 }), false);
 });
+
+test("extractComparableTrayData notices a slot starting to be read", () => {
+    // {"id":"0","state":10} at rest and {"id":"0","state":17} while the AMS
+    // pulls the spool in are the same two fields. Without the busy flag nothing
+    // reprocesses the slot and the label never reaches a client.
+    const atRest = [{ id: "0", tray: [{ id: "0", state: 10, remain: 0, tray_color: "N/A", tray_sub_brands: "N/A", tray_weight: 0, tray_uuid: "N/A" }] }];
+    const busy = [{ id: "0", tray: [{ id: "0", state: 17, remain: 0, tray_color: "N/A", tray_sub_brands: "N/A", tray_weight: 0, tray_uuid: "N/A" }] }];
+
+    assert.notDeepEqual(extractComparableTrayData(atRest), extractComparableTrayData(busy));
+});
+
+test("extractComparableTrayData does not reprocess for every busy state", () => {
+    // The AMS cycles through 1, 5, 17 and 21 on the way in. They all mean the
+    // same thing, so they must cost one update between them, not one each.
+    const state = value => [{ id: "0", tray: [{ id: "0", state: value, remain: 0, tray_color: "N/A", tray_sub_brands: "N/A", tray_weight: 0, tray_uuid: "N/A" }] }];
+
+    assert.deepEqual(extractComparableTrayData(state(1)), extractComparableTrayData(state(5)));
+    assert.deepEqual(extractComparableTrayData(state(5)), extractComparableTrayData(state(21)));
+});

--- a/test/ams.test.js
+++ b/test/ams.test.js
@@ -1,7 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { correctRemainInt, haveSpoolDataChanged, slotIsOccupied, extractComparableTrayData, processData } from "../src/ams.js";
+import { correctRemainInt, haveSpoolDataChanged, slotIsOccupied, extractComparableTrayData, hasTrayDataChanged, processData } from "../src/ams.js";
 
 test("correctRemainInt passes through a full-size spool unchanged", () => {
     assert.equal(correctRemainInt(63, 1000, "PLA"), 63);
@@ -80,6 +80,32 @@ test("correctRemainInt reports an unknown remain as null, never as 0", () => {
     assert.equal(correctRemainInt(0, "1000", "PLA"), 0);
     assert.equal(correctRemainInt(100, "1000", "PLA"), 100);
     assert.equal(correctRemainInt(25, "250", "PLA"), 100);
+});
+
+// G-code mode ignores the remain percentage, but not whether there is one.
+const comparable = remain => [{ id: "0", tray: [
+    { id: "0", tray_uuid: "A6A4F33B", tray_weight: "1000", tray_sub_brands: "PLA Glow", tray_color: "7AC0E9FF", remain },
+] }];
+
+test("hasTrayDataChanged notices the first remain reading arriving", () => {
+    // Captured on a P2S: the slot sat at -1 (null here) for 74 seconds after
+    // the spool went in, then reported 53. Without this the snapshot the create
+    // action reads keeps saying "no reading" and stores the spool as untouched.
+    assert.equal(hasTrayDataChanged(comparable(53), comparable(null)), true);
+});
+
+test("hasTrayDataChanged ignores a drifting remain in G-code mode", () => {
+    // The weight comes from the sliced file there, so a ticking percentage must
+    // not reprocess and log the slot over and over.
+    assert.equal(hasTrayDataChanged(comparable(53), comparable(52)), false);
+    assert.equal(hasTrayDataChanged(comparable(53), comparable(53)), false);
+});
+
+test("hasTrayDataChanged still sees a real change next to a remain tick", () => {
+    const before = comparable(53);
+    const after = comparable(52);
+    after[0].tray[0].tray_color = "FFFFFFFF";
+    assert.equal(hasTrayDataChanged(after, before), true);
 });
 
 // Real tray payloads captured from a P2S with two AMS 2 Pro units. A loaded

--- a/test/ams.test.js
+++ b/test/ams.test.js
@@ -1,7 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { correctRemainInt, haveSpoolDataChanged, slotIsOccupied, extractComparableTrayData } from "../src/ams.js";
+import { correctRemainInt, haveSpoolDataChanged, slotIsOccupied, extractComparableTrayData, processData } from "../src/ams.js";
 
 test("correctRemainInt passes through a full-size spool unchanged", () => {
     assert.equal(correctRemainInt(63, 1000, "PLA"), 63);
@@ -50,6 +50,36 @@ test("haveSpoolDataChanged ignores the order of the Spoolman response", async ()
 
 test("haveSpoolDataChanged detects a changed remaining weight", async () => {
     assert.equal(await haveSpoolDataChanged([spool(1, "AAA", 700)], [spool(1, "AAA", 800)]), true);
+});
+
+// The AMS reports remain -1 for the first 15 to 20 seconds after a spool goes
+// in, and permanently for a chipless one. Captured on a P2S: at 11:39:10 the
+// slot read `remain=-1 state=27 sub="PLA Matte"`, at 11:39:25 `remain=100`.
+test("processData keeps an unreported remain unknown instead of calling it empty", () => {
+    const [ams] = processData([{ id: "0", tray: [
+        { id: "0", state: 27, remain: -1, tray_type: "PLA", tray_sub_brands: "PLA Matte", tray_color: "FFFFFFFF", tray_weight: "1000", tray_uuid: "A5F4AA83" },
+        { id: "1", state: 11, remain: 0,  tray_type: "PLA", tray_sub_brands: "PLA Basic", tray_color: "000000FF", tray_weight: "1000", tray_uuid: "18F1DE9B" },
+    ] }]);
+
+    assert.equal(ams.tray[0].remain, null, "-1 means the AMS has not read it yet");
+    assert.equal(ams.tray[1].remain, 0, "a real 0 is a reading and has to survive");
+});
+
+test("processData does not write the normalised remain back onto the raw slot", () => {
+    // The raw value is what the next report is compared against.
+    const raw = { id: "0", state: 27, remain: -1, tray_color: "FFFFFFFF", tray_sub_brands: "PLA Matte", tray_weight: "1000", tray_uuid: "A5F4AA83" };
+    processData([{ id: "0", tray: [raw] }]);
+    assert.equal(raw.remain, -1);
+});
+
+test("correctRemainInt reports an unknown remain as null, never as 0", () => {
+    assert.equal(correctRemainInt(null, "1000", "PLA"), null);
+    assert.equal(correctRemainInt(undefined, "1000", "PLA"), null);
+    // A spool created from a null here was booked as fully used and came out
+    // at 0 g left, with nothing in G-code mode to correct it afterwards.
+    assert.equal(correctRemainInt(0, "1000", "PLA"), 0);
+    assert.equal(correctRemainInt(100, "1000", "PLA"), 100);
+    assert.equal(correctRemainInt(25, "250", "PLA"), 100);
 });
 
 // Real tray payloads captured from a P2S with two AMS 2 Pro units. A loaded

--- a/test/ams.test.js
+++ b/test/ams.test.js
@@ -1,7 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { correctRemainInt, haveSpoolDataChanged, slotIsOccupied, extractComparableTrayData, hasTrayDataChanged, processData } from "../src/ams.js";
+import { correctRemainInt, haveSpoolDataChanged, slotIsOccupied, extractComparableTrayData, hasTrayDataChanged, findMergeableSpool, processData } from "../src/ams.js";
 
 test("correctRemainInt passes through a full-size spool unchanged", () => {
     assert.equal(correctRemainInt(63, 1000, "PLA"), 63);
@@ -177,4 +177,47 @@ test("extractComparableTrayData still tracks identified spools by their data", (
 
     const same = [{ id: "0", tray: [{ ...bambuTray, id: "0", remain: 50 }] }];
     assert.deepEqual(extractComparableTrayData(a), extractComparableTrayData(same));
+});
+
+/* ---- Merging an untracked spool, with and without a remain reading ---- */
+
+const glowSlot = remain => ({
+    tray_sub_brands: "PLA Glow",
+    tray_type: "PLA",
+    tray_color: "7AC0E9FF",
+    tray_weight: "1000",
+    cols: ["7AC0E9FF"],
+    remain,
+});
+
+const mergeCandidate = (overrides = {}) => ({
+    id: 15,
+    initial_weight: 1000,
+    remaining_weight: 1000,
+    used_weight: 0,
+    extra: {},
+    filament: { material: "PLA Glow", color_hex: "7AC0E9" },
+    ...overrides,
+});
+
+test("findMergeableSpool matches on weight when the AMS reported one", () => {
+    const half = mergeCandidate({ remaining_weight: 500, used_weight: 500 });
+    assert.equal(findMergeableSpool(glowSlot(50), [half])?.id, 15);
+    // 100 % against a spool that is half gone is outside the 15 % tolerance,
+    // and it has been used, so nothing else lets it through either
+    assert.equal(findMergeableSpool(glowSlot(100), [half]), undefined);
+});
+
+test("findMergeableSpool skips the weight test when there is no reading", () => {
+    // Treating the missing value as 0 made the expected remaining weight 0,
+    // which matched every empty spool in the instance.
+    const empty = mergeCandidate({ remaining_weight: 0, used_weight: 1000 });
+    const half = mergeCandidate({ remaining_weight: 500, used_weight: 500 });
+
+    // An untouched spool still merges: never used carries it, not the weight
+    assert.equal(findMergeableSpool(glowSlot(null), [mergeCandidate()])?.id, 15);
+    // A half used one no longer does, because nothing confirms the guess
+    assert.equal(findMergeableSpool(glowSlot(null), [half]), undefined);
+    // An empty spool keeps matching on its own rule, unchanged
+    assert.equal(findMergeableSpool(glowSlot(null), [empty])?.id, 15);
 });

--- a/test/ams.test.js
+++ b/test/ams.test.js
@@ -1,7 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { correctRemainInt, haveSpoolDataChanged, slotIsOccupied, extractComparableTrayData, hasTrayDataChanged, findMergeableSpool, processData } from "../src/ams.js";
+import { correctRemainInt, haveSpoolDataChanged, slotIsOccupied, extractComparableTrayData, hasTrayDataChanged, findMergeableSpool, slotIsBusy, processData } from "../src/ams.js";
 
 test("correctRemainInt passes through a full-size spool unchanged", () => {
     assert.equal(correctRemainInt(63, 1000, "PLA"), 63);
@@ -220,4 +220,39 @@ test("findMergeableSpool skips the weight test when there is no reading", () => 
     assert.equal(findMergeableSpool(glowSlot(null), [half]), undefined);
     // An empty spool keeps matching on its own rule, unchanged
     assert.equal(findMergeableSpool(glowSlot(null), [empty])?.id, 15);
+});
+
+/* ---- Telling a slot being read from one that is simply empty ---- */
+
+// Captured on a P2S while pulling a spool and putting it back. The tray carries
+// two fields the whole time, so `state` is the only thing that moves:
+//   {"id":"0","state":10}  at rest, empty
+//   {"id":"0","state":17}  {"id":"0","state":5}  {"id":"0","state":21}  busy
+// then the full 23 field record arrives with state 11.
+test("slotIsBusy separates a slot being read from one at rest", () => {
+    assert.equal(slotIsBusy({ id: "0", state: 10 }), false);
+    assert.equal(slotIsBusy({ id: "0", state: 9 }), false);
+    assert.equal(slotIsBusy({ id: "0", state: 17 }), true);
+    assert.equal(slotIsBusy({ id: "0", state: 5 }), true);
+    assert.equal(slotIsBusy({ id: "0", state: 21 }), true);
+});
+
+test("slotIsBusy reads a state sent as a string", () => {
+    assert.equal(slotIsBusy({ id: "0", state: "17" }), true);
+    assert.equal(slotIsBusy({ id: "0", state: "10" }), false);
+});
+
+test("slotIsBusy calls an unseen state at rest, not busy", () => {
+    // The wrong way round would leave an empty slot claiming to read a spool
+    // for good. This way it says "Empty slot", which is what it says today.
+    assert.equal(slotIsBusy({ id: "0", state: 42 }), false);
+    assert.equal(slotIsBusy({ id: "0" }), false);
+    assert.equal(slotIsBusy(null), false);
+});
+
+test("slotIsBusy never fires on a slot that actually holds something", () => {
+    // Occupancy is decided by slotIsOccupied, which does not look at state, and
+    // a loaded slot must not be labelled as still being read.
+    assert.equal(slotIsBusy({ ...thirdParty, state: 17 }), false);
+    assert.equal(slotIsBusy({ ...bambuTray, state: 5 }), false);
 });

--- a/test/ams.test.js
+++ b/test/ams.test.js
@@ -52,44 +52,65 @@ test("haveSpoolDataChanged detects a changed remaining weight", async () => {
     assert.equal(await haveSpoolDataChanged([spool(1, "AAA", 700)], [spool(1, "AAA", 800)]), true);
 });
 
-// Real tray payloads observed on a P2S with two AMS units: a Bambu Lab spool,
-// two 3rd party spools the printer cannot identify, and an empty slot. Only
-// `state` tells the last three apart.
-const bambuTray = { state: 11, tray_type: "PLA", tray_sub_brands: "PLA Basic", tray_color: "000000FF", tray_weight: "1000", tray_uuid: "18F1DE9B" };
-const thirdParty10 = { id: "2", state: 10, remain: 0, tray_color: "N/A", tray_sub_brands: "N/A", tray_weight: 0, tray_uuid: "N/A" };
-const thirdParty20 = { id: "2", state: 20, remain: 0, tray_color: "N/A", tray_sub_brands: "N/A", tray_weight: 0, tray_uuid: "N/A" };
-const emptyTray = { id: "0", state: 0, remain: 0, tray_color: "N/A", tray_sub_brands: "N/A", tray_weight: 0, tray_uuid: "N/A" };
+// Real tray payloads captured from a P2S with two AMS 2 Pro units. A loaded
+// slot always carries the full record, whether the chip was read or not; an
+// empty slot carries `id` and `state` and nothing else. `state` separates
+// nothing: 9 and 10 appear on empty slots, 11 and 27 on loaded ones.
+const bambuTray = { id: "0", state: 11, cols: ["000000FF"], tag_uid: "55650E0F00000100", tray_diameter: "1.75", tray_info_idx: "GFA00", tray_type: "PLA", tray_sub_brands: "PLA Basic", tray_color: "000000FF", tray_weight: "1000", tray_uuid: "18F1DE9B", remain: 27 };
+const thirdParty = { id: "0", state: 11, cols: ["0ACC38FF"], tag_uid: "0000000000000000", tray_diameter: "1.75", tray_info_idx: "GFL99", tray_type: "PLA", tray_sub_brands: "N/A", tray_color: "0ACC38FF", tray_weight: "0", tray_uuid: "N/A", remain: 0 };
+const emptyTray = { id: "1", state: 10, remain: 0, tray_color: "N/A", tray_sub_brands: "N/A", tray_weight: 0, tray_uuid: "N/A" };
 
 test("slotIsOccupied separates an unidentified spool from an empty slot", () => {
     assert.equal(slotIsOccupied(emptyTray), false);
-    assert.equal(slotIsOccupied(thirdParty10), true);
-    assert.equal(slotIsOccupied(thirdParty20), true);
+    assert.equal(slotIsOccupied(thirdParty), true);
     assert.equal(slotIsOccupied(bambuTray), true);
 });
 
-test("slotIsOccupied treats a missing state as not occupied", () => {
-    // Rather than inventing spools on firmware that does not report the field
-    assert.equal(slotIsOccupied({ tray_uuid: "N/A" }), false);
-    assert.equal(slotIsOccupied({ state: null }), false);
-    assert.equal(slotIsOccupied(undefined), false);
+test("slotIsOccupied ignores state", () => {
+    // The empty slot reports state 10 and the loaded ones report 11, so reading
+    // "non zero means occupied" made every empty slot look like a 3rd party
+    // spool. Flipping the value must change nothing in either direction.
+    assert.equal(slotIsOccupied({ ...emptyTray, state: 0 }), false);
+    assert.equal(slotIsOccupied({ ...emptyTray, state: 27 }), false);
+    assert.equal(slotIsOccupied({ ...thirdParty, state: 0 }), true);
 });
 
-test("slotIsOccupied reads a state sent as a string", () => {
-    assert.equal(slotIsOccupied({ state: "0" }), false);
-    assert.equal(slotIsOccupied({ state: "10" }), true);
+test("slotIsOccupied handles a missing slot", () => {
+    assert.equal(slotIsOccupied(undefined), false);
+    assert.equal(slotIsOccupied(null), false);
 });
 
 test("extractComparableTrayData notices a 3rd party spool arriving", () => {
     const before = [{ id: "0", tray: [{ ...emptyTray, id: "1" }] }];
-    const after  = [{ id: "0", tray: [{ ...thirdParty10, id: "1" }] }];
+    const after  = [{ id: "0", tray: [{ ...thirdParty, id: "1" }] }];
+    assert.notDeepEqual(extractComparableTrayData(before), extractComparableTrayData(after));
+});
+
+test("extractComparableTrayData notices a 3rd party spool being removed", () => {
+    const before = [{ id: "0", tray: [{ ...thirdParty, id: "1" }] }];
+    const after  = [{ id: "0", tray: [{ ...emptyTray, id: "1" }] }];
+    assert.notDeepEqual(extractComparableTrayData(before), extractComparableTrayData(after));
+});
+
+test("extractComparableTrayData notices material and colour set on the printer", () => {
+    // The AMS keeps the slot unidentified, so only the fields the user set on
+    // the printer change. Comparing occupancy alone hid this completely.
+    const before = [{ id: "0", tray: [{ ...thirdParty, tray_type: "", tray_info_idx: "", tray_color: "N/A" }] }];
+    const after  = [{ id: "0", tray: [thirdParty] }];
+    assert.notDeepEqual(extractComparableTrayData(before), extractComparableTrayData(after));
+});
+
+test("extractComparableTrayData notices one chipless spool swapped for another", () => {
+    const before = [{ id: "0", tray: [thirdParty] }];
+    const after  = [{ id: "0", tray: [{ ...thirdParty, cols: ["F98C36FF"], tray_color: "F98C36FF" }] }];
     assert.notDeepEqual(extractComparableTrayData(before), extractComparableTrayData(after));
 });
 
 test("extractComparableTrayData ignores the state value of an unidentified spool", () => {
-    // 10 and 20 both mean "loaded but unknown"; flipping between them must not
-    // look like a change and trigger a reprocess.
-    const a = [{ id: "0", tray: [{ ...thirdParty10, id: "1" }] }];
-    const b = [{ id: "0", tray: [{ ...thirdParty20, id: "1" }] }];
+    // It varies between reports about the same unchanged slot, so comparing it
+    // would trigger a reprocess on nothing.
+    const a = [{ id: "0", tray: [{ ...thirdParty, state: 10 }] }];
+    const b = [{ id: "0", tray: [{ ...thirdParty, state: 20 }] }];
     assert.deepEqual(extractComparableTrayData(a), extractComparableTrayData(b));
 });
 

--- a/test/mqtt.remain.test.js
+++ b/test/mqtt.remain.test.js
@@ -1,0 +1,51 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { waitedLongEnoughForRemain } from "../src/mqtt.js";
+
+// Creating a Spoolman spool writes its used weight, derived from the AMS remain
+// percentage. The AMS reports none for the first seconds after a spool goes in,
+// measured between 17 and 74 seconds on a P2S, so a spool created in that
+// window is stored as brand new. Creation waits, up to a limit.
+
+const slot = (remain, uuid = "A6A4F33B") => ({ remain, tray_uuid: uuid });
+
+test("a slot with a reading never waits, and clears an earlier wait", () => {
+    const printer = { remainWaits: {} };
+
+    assert.equal(waitedLongEnoughForRemain(printer, "A0", slot(null)), false);
+    assert.equal(waitedLongEnoughForRemain(printer, "A0", slot(100)), true);
+    assert.deepEqual(printer.remainWaits, {}, "the counter is dropped, not left to expire");
+});
+
+test("a slot without a reading waits five updates, then gives up", () => {
+    const printer = { remainWaits: {} };
+
+    for (let update = 1; update <= 5; update++) {
+        assert.equal(waitedLongEnoughForRemain(printer, "A0", slot(null)), false, `update ${update}`);
+    }
+    // Better a spool stored as full than a spool never created at all, for a
+    // chip that reports nothing.
+    assert.equal(waitedLongEnoughForRemain(printer, "A0", slot(null)), true);
+});
+
+test("a different spool in the same slot starts the wait over", () => {
+    const printer = { remainWaits: {} };
+
+    for (let update = 1; update <= 5; update++) waitedLongEnoughForRemain(printer, "A0", slot(null));
+    assert.equal(waitedLongEnoughForRemain(printer, "A0", slot(null, "OTHER")), false);
+    assert.equal(printer.remainWaits.A0.waits, 1);
+});
+
+test("slots are counted apart", () => {
+    const printer = { remainWaits: {} };
+
+    for (let update = 1; update <= 6; update++) waitedLongEnoughForRemain(printer, "A0", slot(null));
+    assert.equal(waitedLongEnoughForRemain(printer, "A1", slot(null, "B19E8E14")), false);
+});
+
+test("a printer created before the counter existed does not crash", () => {
+    const printer = {};
+    assert.equal(waitedLongEnoughForRemain(printer, "A0", slot(null)), false);
+    assert.deepEqual(printer.remainWaits, { A0: { uuid: "A6A4F33B", waits: 1 } });
+});

--- a/test/spoolman.test.js
+++ b/test/spoolman.test.js
@@ -130,12 +130,21 @@ test("both creation paths build the same spool", () => {
 });
 
 test("a slot reporting nothing left creates a spool with everything used", () => {
-    // processData clamps a missing or negative remain to 0, so this is also what
-    // a spool the AMS cannot estimate looks like
     const payload = buildSpoolPayload({ slot: { ...bambuSlot, remain: 0 } }, 7);
 
     assert.equal(payload.initial_weight, 1000);
     assert.equal(payload.used_weight, 1000);
+});
+
+test("a slot with no remain reading yet creates a full spool, not an empty one", () => {
+    // processData turns the AMS -1 into null, which lasts the 15 to 20 seconds
+    // between inserting a spool and the RFID percentage arriving. Creating in
+    // that window used to book the whole spool as used, and in G-code mode
+    // nothing patches the weight afterwards, so it stayed at 0 g left.
+    const payload = buildSpoolPayload({ slot: { ...bambuSlot, remain: null } }, 7);
+
+    assert.equal(payload.initial_weight, 1000);
+    assert.equal(payload.used_weight, 0);
 });
 
 test("the remain percentage is rescaled to the real spool size", () => {

--- a/test/uispool.test.js
+++ b/test/uispool.test.js
@@ -106,6 +106,41 @@ test("a missing assignment reads as false rather than absent", () => {
     assert.equal(client.enableButton, "false");
 });
 
+test("the N/A placeholder does not reach a client", () => {
+    // processData writes "N/A" into every field the printer left out. It is a
+    // backend marker, and a client that receives it renders it, which is how an
+    // emptied slot ended up labelled "N/A" with a `#N/A` colour swatch.
+    const client = toClientSpool({
+        amsId: "A0",
+        slotState: "Empty",
+        slot: { id: 0, state: 10, remain: 0, tray_color: "N/A", tray_sub_brands: "N/A", tray_weight: 0, tray_uuid: "N/A" },
+    });
+
+    assert.equal(client.slot.tray_uuid, null);
+    assert.equal(client.slot.tray_color, null);
+    assert.equal(client.slot.tray_sub_brands, null);
+    assert.equal(client.slot.tray_type, null);
+    assert.equal(client.filamentName, null);
+    assert.equal(client.material, null);
+});
+
+test("a 3rd party slot keeps what the printer does know", () => {
+    // Material and colour set on the AMS are real values and have to survive,
+    // even though the same record carries placeholders next to them.
+    const client = toClientSpool({
+        amsId: "B0",
+        slotState: "Loaded (3rd party)",
+        slot: { id: 0, state: 11, tray_info_idx: "GFL99", tray_type: "PLA", tray_sub_brands: "N/A", tray_color: "0ACC38FF", tray_weight: "0", tray_uuid: "N/A", remain: 0 },
+    });
+
+    assert.equal(client.slot.tray_type, "PLA");
+    assert.equal(client.slot.tray_color, "0ACC38FF");
+    assert.equal(client.slot.tray_uuid, null);
+    assert.equal(client.material, "PLA");
+    assert.equal(client.filamentName, null);
+    assert.equal(client.key, "GFL99|0ACC38");
+});
+
 test("a change the UI does not show does not trigger a broadcast", () => {
     const prev = uiSpool();
     const next = uiSpool({ slot: { ...uiSpool().slot, bed_temp: "60", nozzle_temp_max: "250" } });


### PR DESCRIPTION
## The report

Removing a 3rd party spool changed nothing in the Web UI. Putting one into an
empty slot and setting its material and colour on the printer changed nothing
either. Only inserting a Bambu Lab spool with a readable chip made everything
catch up at once, including the 3rd party slots. After any removal the slot did
not read as empty but as "N/A".

## Root cause

`slotIsOccupied()` read the undocumented `state` field as "non zero means
occupied". On a P2S with two AMS 2 Pro units, an empty slot reports `state` 9 or
10 and a loaded one 11 or 27, so every empty slot counted as occupied.

That sent it down the 3rd party branch of `processSlot`, which is the "N/A" row
with an "Assign Spool" button, and it pinned the `occupied` flag that
`extractComparableTrayData()` reduces an unidentified tray to. An empty slot and
a chipless spool produced a byte identical projection, so the tray data never
looked changed and the slot was never processed.

Verified against the reporter's own capture: at 12:55:51 slots A0 and A1 were
both empty, at 12:56:40 A0 was empty and A1 held a chipless PLA spool, and the
projection of that AMS unit was identical between the two.

Occupancy now comes from the shape of the tray record. A loaded slot carries the
full payload, `tray_info_idx` (`GFL99` for anything the AMS cannot identify),
`tray_type`, `cols` and `tag_uid` included, whether the chip was read or not. An
empty slot carries `id` and `state` and nothing else.

## What else this uncovered

Testing the fix against the live printer turned up three more defects on the
same path.

**Slot updates were suppressed.** `shouldSendSlotUpdate()` held back every slot
the printer had not fully identified, so an emptied slot never went out over
SSE. It was guarding against the sparse payload of an empty slot overwriting a
populated row, which was the occupancy bug rather than a real case.
`hasSpoolUiChanged()` already drops everything that would not change the
display, so it is the only condition now.

**The "N/A" marker reached clients.** `processData()` writes it into every field
the printer left out, as something the backend branches on, and `toClientSpool()`
passed it straight through. The projection turns it, and the empty string, back
into `null`.

**New spools were created empty.** The AMS answers `remain: -1` between a spool
going in and its RFID percentage arriving, measured on a P2S at anything from 17
seconds to over a minute, and forever for a chipless spool. That was clamped to
0, which is a real reading meaning "empty", and `usedWeightFromSlot()` then
booked the whole spool as used. In G-code mode nothing patches the weight
afterwards, so it stayed at 0 g left. Three spools were created that way during
the investigation.

An unreported `remain` is `null` now, from `processData()` through
`correctRemainInt()`, and each caller decides what to do without a reading:
create the spool full, skip the legacy weight PATCH, skip the weight comparison
when looking for a mergeable spool, render a dash.

## Two waiting states

Creation is held back until the AMS reports how much is left, in both operation
modes: automatic skips the slot for that update, manual shows a disabled
"Waiting for data" button. It gives up after five updates so a chip that never
reports still gets its spool. Merging is deliberately not held back, it writes
only the tag, never a weight.

The wait resolves itself because the arrival of the first reading is now a
change. G-code mode still drops the remain value before change detection, but
keeps whether there is one, so a drifting percentage costs nothing while the
first reading refreshes `printer.spoolData`. That snapshot is what the create
and merge actions build their payload from, and without the refresh a spool
inserted at 53 % was stored as untouched.

While the AMS is still reading, the slot reports `{ id, state }` and nothing
else, byte for byte an empty slot, so the dashboard called it empty with the
user watching the spool sit in it. `slotIsBusy()` labels that case, and it is
the only thing left that reads `state`. It decides a label and nothing else. Its
allow list holds the values seen while busy rather than the ones seen at rest,
so a value nobody has observed yet reads as empty, which is what the slot says
today, instead of leaving an empty slot claiming to read a spool for good. The
flag is part of the comparison, otherwise the label only appeared when another
slot happened to change in the same update.

## Verification

Every change was exercised against the reporting printer in a container built
from this branch, in both operation modes and at 2, 5 and 15 second update
intervals:

- a 3rd party spool removed and inserted, and its material and colour set on the
  printer
- an emptied slot reading "Empty slot" rather than "N/A"
- a spool created inside the unknown window, `used_weight 0` instead of `1000`
- a spool created after the reading arrived, using the fresh value
- a merge
- the full insert sequence: "Reading spool" with a disabled button, then the
  spool row with the same button, then the real action

177 tests pass, 25 more than before. `slotIsOccupied`, `slotIsBusy`,
`hasTrayDataChanged`, `waitedLongEnoughForRemain` and `findMergeableSpool` are
covered, the last of which had no tests at all. The fixtures that described a
3rd party spool were replaced: they were an empty slot.

`src/AGENTS.md` records what `state` does and does not mean, and that a `remain`
of `null` is not an empty spool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
