### PR TITLE
Bump the version to 1.3.0-dev.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 -----------------------------------------------------------------------------------------------
-Unreleased
+Version 1.3.0-dev.4
    - Fixes:
       - Multi colour spools (PLA Silk Multi-Color, PLA Basic Gradient, TPU 90A Blaze and Frozen) show all of their colours again instead of only the first one
          - The AMS reports every colour of a spool in cols and only the first of them in tray_color. cols never left the server: the client projection did not carry it, so the Web UI drew a two colour spool as if it were plain

--- a/OPEN.md
+++ b/OPEN.md
@@ -162,7 +162,7 @@ None of this involved real hardware, so it says nothing about the items above.
 ## Before the next official release
 
 The version deliberately stays on a `-dev` prerelease for now, currently
-`1.3.0-dev.3`.
+`1.3.0-dev.4`.
 
 - [ ] Set the version to `1.3.0` in **both** `package.json` and `src/config.js`.
   The publish workflow compares the tag against `package.json` and aborts on a
@@ -173,7 +173,7 @@ Tag behaviour, after the hardening in `c053561`:
 | Tag | Images | `:latest` | GitHub release |
 |---|---|---|---|
 | `v1.3.0` | `:1.3.0` and `:latest` | moved | release, marked Latest |
-| `v1.3.0-dev`, `v1.3.0-dev.2`, `v1.3.0-dev.3` | `:<version>` and `:dev` | untouched | pre-release |
+| `v1.3.0-dev`, `v1.3.0-dev.2`, `v1.3.0-dev.3`, `v1.3.0-dev.4` | `:<version>` and `:dev` | untouched | pre-release |
 | `v1.3.0-rc1` and other suffixes | `:<version>` only | untouched | pre-release |
 
 One `case` decides all four columns, so the image tags and the release cannot

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bambulab-ams-spoolman-filamentstatus",
-  "version": "1.3.0-dev.3",
+  "version": "1.3.0-dev.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bambulab-ams-spoolman-filamentstatus",
-      "version": "1.3.0-dev.3",
+      "version": "1.3.0-dev.4",
       "license": "ISC",
       "dependencies": {
         "adm-zip": "^0.6.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "mqtt": "^5.15.2"
   },
   "name": "bambulab-ams-spoolman-filamentstatus",
-  "version": "1.3.0-dev.3",
+  "version": "1.3.0-dev.4",
   "main": "app.js",
   "type": "module",
   "engines": {

--- a/src/config.js
+++ b/src/config.js
@@ -29,7 +29,7 @@ export const settingsPath = path.join(dataDir, "settings.json");
 // brings the service back on its own or depends on the container policy.
 export const supervised = process.env.SUPERVISED === "1";
 
-export const version = "1.3.0-dev.3";
+export const version = "1.3.0-dev.4";
 export const PORT = 4000;
 export const RECONNECT_INTERVAL = 60000;
 


### PR DESCRIPTION
Prepares the next prerelease tag, `v1.3.0-dev.4`.

## What changes

* `package.json`, `package-lock.json` and `src/config.js` are bumped together. The publish workflow compares the tag against `package.json`, and `src/config.js` is what the Web UI and the diagnostics bundle report, so a bump in only one of them either fails the build or ships an image that lies about its version.
* The changelog section that was called `Unreleased` becomes `Version 1.3.0-dev.4`. Everything in it ships with this tag, and the release body is that section, so a tag without a matching one would come out with no notes.
* `OPEN.md` lists the new tag next to the other prereleases and names the current version.

No code changes. What the tag will carry is the shared consumption match from #90, together with the profile stage fix and the multi colour and G-code tracking work already listed in that section.

## Verification

`npm test`: 250 pass, 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)