### PR TITLE
One file for what the dashboard and the server both compute

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,7 @@ matter for them are below.
 | `starting.js` | The service process. Global error handlers, signal handling, then dynamic-imports `backend.js`. Forked by `entrypoint.js`, so the handlers live where the application does. |
 | `backend.js` | Express app, static hosting, startup sequence: Spoolman health, vendor and extra-field bootstrap, printer log files, monitor loops. |
 | `src/` | All backend logic. See its AGENTS.md. |
-| `public/` | Vanilla JS/HTML/CSS frontend. No build step, no framework, no bundler; files are served as-is. `menu.js` renders the menu bar and owns the dark mode button for every page, so each page includes it before its own script and provides an empty `#menu-root` in its `#menubar`. |
+| `public/` | Vanilla JS/HTML/CSS frontend. No build step, no framework, no bundler; files are served as-is. `menu.js` renders the menu bar and owns the dark mode button for every page, so each page includes it before its own script and provides an empty `#menu-root` in its `#menubar`. `shared.js` holds the pure decisions the frontend and the server both make; it lives here because a browser has to be able to load it unbuilt, and `src/` imports it from here. |
 | `test/` | `node:test` suites (`npm test`). Fixtures in `test/fixtures/` are real slicer output, not synthetic. |
 | `printers/` | Runtime data, gitignored. `printers.json` (printer list), `settings.json` (runtime configuration) and `mappings.json` (slot assignments). All three are written by the service and editable by hand. |
 | `logs/` | Runtime logs, gitignored. One file per printer plus `server.log`. |
@@ -197,6 +197,12 @@ Not punctuation, and therefore allowed:
 - Duplicating the settings schema in the frontend. `public/settings.js` renders
   whatever `/api/settings` describes, so a new field only has to be added to
   `SETTINGS_SCHEMA`.
+- Answering a question in `public/` that the server already answers. Either read
+  the answer off the payload, the way the dashboard reads `matchedAmsId` rather
+  than matching consumption itself, or put the decision in `public/shared.js`
+  and import it on both sides. A second implementation drifts, and `public/` has
+  no coverage of its own to catch it: `test/shared.test.js` is what makes the
+  shared file testable at all.
 - Adding a direct dependency without putting it in `package.json`. The Docker
   image installs from `package.json` and `package-lock.json` only, so relying on
   a transitive package works locally and breaks in the container.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 Unreleased
    - Fixes:
       - The Web UI no longer flashes the light theme when a page is opened in dark mode. The class that carries the theme was set by menu.js at the end of the body, so the browser painted the light stylesheet first and switched afterwards, on every page change. A small script in each page head now sets it on the html element before the first paint, and the stylesheet matches it there
+      - A slot holding a spool the printer cannot identify no longer draws a swatch out of the placeholder the printer sends. The dashboard turned the literal "N/A" into a colour and handed "#N/A" to CSS, where the server had always dropped it
+   - Development:
+      - The colour and weight rules the dashboard and the server both apply live in one file, public/shared.js, imported by both. Four functions in public/frontend.js were a second implementation of them, and the placeholder above is what a second implementation drifting apart looks like
+         - It sits under public/ because that is the half that cannot import from anywhere else: no build step, no dependencies, served straight from disk. The server imports it from there, so the arrow points one way and there is nothing to keep in step
+         - test/shared.test.js covers it with plain node:test, which is the first coverage anything in public/ has had. It also asserts that the server re-exports those functions rather than holding a copy, and that public/frontend.js still imports them
+         - public/index.html loads frontend.js as a module, which is what lets it import at all. Nothing else about the frontend changed: no build step, no bundler, no framework
 
 -----------------------------------------------------------------------------------------------
 Version 1.3.0-dev.4

--- a/OPEN.md
+++ b/OPEN.md
@@ -166,7 +166,9 @@ The version deliberately stays on a `-dev` prerelease for now, currently
 
 - [ ] Set the version to `1.3.0` in **both** `package.json` and `src/config.js`.
   The publish workflow compares the tag against `package.json` and aborts on a
-  mismatch, so a bump in only one of them fails the build.
+  mismatch, so a bump in only one of them fails the build. Not to be done ahead
+  of time: the bump happens when the release is actually wanted, and Niklas says
+  when that is.
 
 Tag behaviour, after the hardening in `c053561`:
 
@@ -188,7 +190,7 @@ tag that already has a release edits it rather than failing.
 Publishing from a branch is rejected outright, so the "Run workflow" button can
 no longer overwrite `:latest` with whatever is on `main`.
 
-## Deadline: armv7 and Node 22
+## Decided: armv7 stays, on Node 22
 
 Node 22 entered maintenance on 2025-10-21 and reaches end of life on
 **2027-04-30**. It is also the last Node that exists on 32 bit ARM at all, so
@@ -206,13 +208,15 @@ package:
 | unofficial-builds.nodejs.org | armv6 only for 22, nothing for 24 and later |
 | Alpine's own `nodejs` package, armhf | 22.23.2, so no way forward either |
 
-So there is no supported path to Node 24 or later on 32 bit ARM. When Node 22
-goes end of life the choice is:
+So there is no supported path to Node 24 or later on 32 bit ARM. The choice was
+to drop `linux/arm/v7` from the publish matrix on 2027-04-30, or to keep
+shipping on a Node that no longer gets security fixes.
 
-- [ ] Decide before 2027-04-30: drop `linux/arm/v7` from the publish matrix and
-  leave 32 bit users on the last image built for them, or keep shipping on an
-  end of life Node with no security fixes. There is no third option, so this is
-  a decision rather than a task.
+**Decided on 2026-09-02: keep shipping on Node 22 and keep `linux/arm/v7`.** A
+32 bit user is left with a working image rather than with none, and the service
+talks to a printer and a Spoolman instance on the user's own LAN rather than to
+the internet. Revisit only if a Node 22 vulnerability actually reaches this
+service; there is nothing to do before then.
 
 A 64 bit OS sidesteps it entirely. A Raspberry Pi 3B and newer are all 64 bit
 capable, and `linux/arm64` stays supported.
@@ -271,16 +275,6 @@ container run. Still unverified:
 - [ ] **A restart through the Web UI during a running print.** The guard asks
   first and the booking of that job is lost when it is forced, which is what the
   dialog says, but it was never observed on a real print.
-
-### Still open
-
-- [ ] **The Home Assistant add-on repository needs a note.** The add-on passes
-  its options as environment variables, and those stop having an effect once a
-  user saves on the settings page, because the file owns the values from then
-  on. The README of this repository says so; the add-on's does not.
-  Since environment configuration is deprecated the add-on also triggers the
-  deprecation hint on every start, which will look like a defect to an add-on
-  user until its README explains which of the two places owns the values.
 
 ### Decisions taken along the way
 
@@ -380,11 +374,11 @@ note that the code sits in plain text in `printers.json` is the honest version.
   own subsection, and legacy mode has a section of its own pointing at the v1.2.1
   README.
 
-The Home Assistant integration in `ha-bambulab-ams-spoolman-filamentstatus`
-needs no change. It only calls `/api/printers`,
-`/api/printer/{id}/monitoring/start|stop` and `/api/status/{id}`, none of which
-changed, and it sets no environment variables of its own. The add-on wrapper is
-a different matter, see the note in the settings section above.
+The Home Assistant side is out of scope for this repository. The integration in
+`ha-bambulab-ams-spoolman-filamentstatus` only drives the AMS monitoring toggle
+per printer, through `/api/printers`,
+`/api/printer/{id}/monitoring/start|stop` and `/api/status/{id}`. None of those
+changed and it sets no environment variables, so nothing here is a task for it.
 
 ## Known gaps, by design
 

--- a/OPEN.md
+++ b/OPEN.md
@@ -380,6 +380,36 @@ per printer, through `/api/printers`,
 `/api/printer/{id}/monitoring/start|stop` and `/api/status/{id}`. None of those
 changed and it sets no environment variables, so nothing here is a task for it.
 
+## Decided: one file for what both halves compute
+
+`public/shared.js` holds the pure functions the dashboard and the server both
+apply to the same payloads: `normColor`, `slotColors`, `filamentColors` and
+`correctRemainInt`. `src/utils.js`, `src/gcode.js` and `src/ams.js` re-export
+them so every existing caller keeps its import, and `public/frontend.js` imports
+them directly.
+
+It lives under `public/` rather than in `src/` because that is the half with the
+constraint: the directory is served straight from disk, has no build step and no
+dependencies, so the browser has to be able to load the file as it is. The
+server has no such limit, which is why it imports across rather than the other
+way round. Whatever is added there has to keep working in both places: no Node
+built-ins, no DOM.
+
+`test/shared.test.js` is the first coverage anything under `public/` has, and it
+asserts the arrangement as well as the behaviour: that the server re-exports
+those functions rather than holding a copy, and that `public/frontend.js` still
+imports them. A future second implementation fails a test rather than waiting
+for a user to notice, which is how the last two were found.
+
+The rest of `public/frontend.js` still has no tests, and that has not changed.
+What can be moved into the shared file is what can be covered; the DOM around it
+cannot be, without adding the build step the directory exists to avoid.
+
+`public/index.html` loads `frontend.js` as a module, which is what makes the
+import possible. `menu.js` stays a classic script and `frontend.js` still calls
+`initMenubar` as a global, because modules run after classic scripts and before
+`DOMContentLoaded`.
+
 ## Known gaps, by design
 
 Not tasks. Decisions and limits worth not relitigating.

--- a/README.md
+++ b/README.md
@@ -299,9 +299,6 @@ Configuring this service through **environment variables** and a hand-written **
 
 The full list of variables and the `printers.json` format are documented in the **[README of v1.2.1](https://github.com/Rdiger-36/bambulab-ams-spoolman-filamentstatus/blob/v1.2.1/README.md)**.
 
-> [!NOTE]
-> **Home Assistant add-on users:** the add-on passes its options as environment variables, and those only seed a setting that has never been saved. As soon as you save on the settings page, `printers/settings.json` owns the values and changing an add-on option has no effect any more. Configure through the add-on options or through the settings page, not both.
-
 Three variables are container level and stay as they are, they have no field in the Web UI:
 
 | Variable | Description |

--- a/public/frontend.js
+++ b/public/frontend.js
@@ -1,3 +1,10 @@
+import {
+	correctRemainInt,
+	filamentColors,
+	normColor,
+	slotColors,
+} from "./shared.js";
+
 let autoButton = null;
 // When false (default) the spool weight is tracked from the sliced G-code, so the
 // main table shows the Spoolman remaining weight instead of the AMS RFID remain %.
@@ -10,26 +17,6 @@ let spoolmanConnected = false;
 let lastLegacyCtx = null;
 // Printer name, used to suggest a location matching the SET_LOCATION format.
 let currentPrinterName = "";
-
-// Mirrors src/ams.js correctRemainInt: Bambu reports remain% on a 1kg basis
-// for regular color filament <1kg, but support/accessory material (tray_type
-// suffix "-S") is measured relative to its actual spool size already.
-function correctRemainIntJS(remainOn1kgBasis, trayWeight, trayType) {
-	const remain = parseFloat(remainOn1kgBasis);
-	// Mirrors correctRemainInt in src/ams.js: the AMS reports no percentage for
-	// the first seconds after a spool goes in, and null must not become 0.
-	if (!Number.isFinite(remain)) return null;
-	const weight = parseFloat(trayWeight);
-	const isSupportMaterial = typeof trayType === "string" && trayType.endsWith("-S");
-
-	if (weight < 1000 && !isSupportMaterial) {
-		let percent = ((remain / 100) * 1000 / weight) * 100;
-		if (percent > 100) percent = 100;
-		if (percent < 0) percent = 0;
-		return Math.round(percent);
-	}
-	return Math.round(remain);
-}
 
 // Initialize the document once it has fully loaded
 document.addEventListener("DOMContentLoaded", () => {
@@ -355,25 +342,6 @@ document.addEventListener("DOMContentLoaded", () => {
         });
     }
     
-    // Every colour of an AMS slot, in the order the printer reported them.
-    // `cols` is the full set and `tray_color` only ever the first of them, so
-    // the single field is a fallback for a payload that predates `cols` rather
-    // than the value to read.
-    function slotColorsJS(slot) {
-        const cols = Array.isArray(slot?.cols) ? slot.cols.filter(Boolean) : [];
-        if (cols.length) return cols.map(normColorJS);
-        return slot?.tray_color ? [normColorJS(slot.tray_color)] : [];
-    }
-
-    // Every colour of a Spoolman filament. Single and multi colour records are
-    // mutually exclusive there: a multi colour filament carries no color_hex.
-    function filamentColorsJS(filament) {
-        if (filament?.multi_color_hexes) {
-            return filament.multi_color_hexes.split(",").filter(Boolean).map(normColorJS);
-        }
-        return filament?.color_hex ? [normColorJS(filament.color_hex)] : [];
-    }
-
     // The CSS background showing a whole colour set in one box.
     //
     // `direction` is Spoolman's multi_color_direction. A "longitudinal"
@@ -403,7 +371,10 @@ document.addEventListener("DOMContentLoaded", () => {
     function swatchHtml(colors, direction = null) {
         const background = colorSetBackground(colors, direction);
         if (!background) return "";
-        const title = colors.map(c => `#${c}`).join(" ");
+        // Uppercase only here: the sets arrive lowercased, because that is the
+        // case the colour comparisons settled on, and a hex reads as a colour
+        // in upper.
+        const title = colors.map(c => `#${normColor(c)}`).join(" ");
         return `<span class="gc-swatch" style="background:${background}" title="${title}"></span>`;
     }
 
@@ -453,12 +424,12 @@ document.addEventListener("DOMContentLoaded", () => {
 	    // Compared as a set rather than as a single hex, so a multi colour spool
 	    // can reach the top for its own slot. Those carry no color_hex at all,
 	    // so against the single field they always ranked last.
-	    const slotColors   = [...slotColorsJS(slot)].sort().join(",");
+	    const slotColorSet = [...slotColors(slot)].sort().join(",");
 
 	    const score = (sp) => {
 	        const material = (sp.filament?.material || "").toUpperCase();
-	        const colors   = [...filamentColorsJS(sp.filament)].sort().join(",");
-	        if (material && material === slotMaterial && colors && colors === slotColors) return 0;
+	        const colors   = [...filamentColors(sp.filament)].sort().join(",");
+	        if (material && material === slotMaterial && colors && colors === slotColorSet) return 0;
 	        if (material && material === slotMaterial) return 1;
 	        return 2;
 	    };
@@ -472,7 +443,7 @@ document.addEventListener("DOMContentLoaded", () => {
 	    const fil   = sp.filament || {};
 	    const parts = [fil.vendor?.name, fil.material, fil.name].filter(Boolean);
 	    const left  = sp.remaining_weight != null ? `${Math.round(sp.remaining_weight)}g left` : "unknown weight";
-	    const swatch = swatchHtml(filamentColorsJS(fil), fil.multi_color_direction);
+	    const swatch = swatchHtml(filamentColors(fil), fil.multi_color_direction);
 	    return `${swatch}#${sp.id} ${parts.join(" · ") || "Unknown filament"} <span class="gc-muted">(${left})</span>`;
 	}
 
@@ -548,7 +519,7 @@ document.addEventListener("DOMContentLoaded", () => {
 	function slotDefaults(slot) {
 	    return {
 	        material: slot.tray_type || "",
-	        color: normColorJS(slot.tray_color) || "000000",
+	        color: normColor(slot.tray_color) || "000000",
 	    };
 	}
 
@@ -687,7 +658,7 @@ document.addEventListener("DOMContentLoaded", () => {
 	    // Keep the picker and the hex field in sync
 	    $("sp-colour-pick").addEventListener("input", () => { $("sp-colour").value = $("sp-colour-pick").value.replace("#", "").toUpperCase(); });
 	    $("sp-colour").addEventListener("input", () => {
-	        const hex = normColorJS($("sp-colour").value);
+	        const hex = normColor($("sp-colour").value);
 	        if (/^[0-9A-F]{6}$/.test(hex)) $("sp-colour-pick").value = `#${hex}`;
 	    });
 
@@ -849,7 +820,7 @@ document.addEventListener("DOMContentLoaded", () => {
 	    // are drawn, and the AMS does not report it, so it comes from whichever
 	    // filament record was matched.
 	    const direction = fil?.multi_color_direction ?? amsSpool.matchingExternalFilament?.multi_color_direction ?? null;
-	    const color = isEmpty ? "" : swatchHtml(slotColorsJS(slot), direction);
+	    const color = isEmpty ? "" : swatchHtml(slotColors(slot), direction);
 
 	    const spoolmanBaseUrl = (document.getElementById("spoolmanLink")?.href || "").replace(/\/+$/, "");
 	    const spoolman = amsSpool.existingSpool?.id
@@ -972,12 +943,6 @@ document.addEventListener("DOMContentLoaded", () => {
 	// Slots that stand alone rather than filling a four slot AMS unit.
 	function isSingleSlotUnit(amsId) {
 	    return amsId === EXTERNAL_SLOT || amsId.startsWith("HT-");
-	}
-
-	// Mirrors normColor in src/gcode.js: slice colors carry a leading "#" and AMS
-	// colors carry a trailing alpha byte, so both are trimmed to bare 6-digit hex.
-	function normColorJS(color) {
-	    return String(color || "").replace(/^#/, "").slice(0, 6).toUpperCase();
 	}
 
 	function gcodeStateBadge(state) {
@@ -1154,7 +1119,7 @@ document.addEventListener("DOMContentLoaded", () => {
 	    } else if (onSpool == null && !isEmpty && slot.remain != null && totalSpool) {
 	        // Fallback if correctedWeight wasn't provided by the backend: derive
 	        // it client-side from the AMS remain%, same as the legacy table does.
-	        const pct = correctRemainIntJS(slot.remain, totalSpool, slot.tray_type);
+	        const pct = correctRemainInt(slot.remain, totalSpool, slot.tray_type);
 	        onSpool = Math.round((pct / 100) * totalSpool);
 	    }
 
@@ -1204,7 +1169,7 @@ document.addEventListener("DOMContentLoaded", () => {
 	    for (const e of missing) {
 	        // The sliced file names one colour per filament, so there is never a
 	        // set to draw here, unlike on a slot.
-	        const swatch = swatchHtml(e.color ? [normColorJS(e.color)] : []);
+	        const swatch = swatchHtml(e.color ? [normColor(e.color)] : []);
 	        const label = e.type ? `${e.type} <code>${e.tray_info_idx}</code>` : `<code>${e.tray_info_idx}</code>`;
 	        html += `<tr><td>${swatch}${label}</td>
 	            <td class="gc-required-amount">${e.grams}g needed</td></tr>`;

--- a/public/index.html
+++ b/public/index.html
@@ -75,7 +75,10 @@
   </footer>
 
   <script src="menu.js"></script>
-  <script src="frontend.js"></script>
+  <!-- A module, so it can import the decisions it shares with the server from
+       shared.js. Modules are deferred, so it still runs before DOMContentLoaded
+       and after menu.js, whose functions it calls as globals. -->
+  <script type="module" src="frontend.js"></script>
 
   <dialog id="notice-dialog">
     <h3 id="notice-dialog-title"></h3>

--- a/public/shared.js
+++ b/public/shared.js
@@ -1,0 +1,130 @@
+/**
+ * The handful of pure decisions the dashboard and the server both have to make.
+ *
+ * It lives under `public/` because that is the half that cannot import from
+ * anywhere else: the directory is served straight from disk, has no build step
+ * and no dependencies, so a browser has to be able to load this file as it is.
+ * The server has no such constraint and imports it from here, which is why the
+ * arrow points this way rather than the other.
+ *
+ * Everything in here is a pure function of its arguments. Nothing touches the
+ * DOM, the filesystem or the network, so `test/shared.test.js` can cover it
+ * with plain `node:test` and both sides inherit the same cases.
+ *
+ * Whatever is added here has to keep working in both places: no Node built-ins,
+ * no DOM, ES module syntax only.
+ */
+
+/**
+ * A colour reduced to the six hex digits every side can compare.
+ *
+ * Slice colours arrive as "#000000", AMS colours as "000000FF" with a trailing
+ * alpha byte, and Spoolman stores bare hex. Dropping the "#" and everything
+ * past the sixth digit is what makes the three comparable at all. Case is left
+ * to the caller, because the two sides settled on different ones long before
+ * this file existed: see `normColor` and `slotColors` below.
+ */
+function bareHex(color) {
+    return String(color).replace(/^#/, "").slice(0, 6);
+}
+
+/**
+ * Normalises a colour to a bare 6-digit uppercase hex (no "#", no alpha) so
+ * slice colours ("#000000") and AMS slot colours ("000000FF") compare equal.
+ *
+ * Uppercase because the consumption keys built from it are compared against
+ * each other, never against a colour set from `slotColors()`.
+ *
+ * @param {*} c - anything a colour may arrive as
+ * @returns {string} the normalised colour, or "" when there was none
+ */
+export function normColor(c) {
+    if (!c) return "";
+    return bareHex(c).toUpperCase();
+}
+
+/**
+ * Every colour of an AMS slot, in the order the printer reported them.
+ *
+ * AMS colours carry a trailing alpha byte that no Spoolman or SpoolmanDB record
+ * has, so every comparison has to drop it first. Reading `cols` rather than
+ * `tray_color` is what makes a multi colour filament comparable at all: the
+ * single field only ever holds the first colour, so it is the fallback for a
+ * payload that predates `cols` rather than the value to read.
+ *
+ * "N/A" is the placeholder an unidentified slot reports, not a colour, and is
+ * dropped rather than normalised into the string "N/A".
+ *
+ * Order is the one the printer reported, because it is the order the colours
+ * sit on the filament and the order the UI draws them in. Callers comparing
+ * colour sets sort a copy; Spoolman and SpoolmanDB do not agree on an order.
+ *
+ * Lowercase, because the sets it produces are compared against Spoolman and
+ * SpoolmanDB records, which are lowercased to meet it. `normColor()` above is
+ * the uppercase one and the two are never compared with each other.
+ *
+ * @param {object} slot - an AMS slot, normalised or raw
+ * @returns {string[]} the colours, possibly empty
+ */
+export function slotColors(slot) {
+    const raw = Array.isArray(slot?.cols) && slot.cols.length ? slot.cols : [slot?.tray_color];
+    return raw
+        .filter(color => color && color !== "N/A")
+        .map(color => bareHex(color).toLowerCase());
+}
+
+/**
+ * Every colour of a Spoolman filament, in the same shape and case as
+ * `slotColors()` so the two can be compared directly.
+ *
+ * Single and multi colour records are mutually exclusive in Spoolman: a multi
+ * colour filament carries its set in `multi_color_hexes` and no `color_hex` at
+ * all. A trailing separator in that field yields an empty entry, which is
+ * dropped rather than compared as a colour.
+ *
+ * @param {object} filament - a Spoolman filament record
+ * @returns {string[]} the colours, possibly empty
+ */
+export function filamentColors(filament) {
+    const raw = filament?.multi_color_hexes
+        ? String(filament.multi_color_hexes).split(",")
+        : [filament?.color_hex];
+    return raw
+        .filter(Boolean)
+        .map(color => bareHex(color).toLowerCase());
+}
+
+/**
+ * The remaining percentage of the spool that is actually in the slot.
+ *
+ * Bambu reports `remain` on a 1kg basis for regular colour filament, so a 500 g
+ * spool that is half empty reports 25%. Support and accessory material
+ * (`tray_type` suffix "-S", e.g. "PLA-S") is sold and measured at its real
+ * spool size and is already relative to `tray_weight`, so rescaling it would be
+ * wrong twice over.
+ *
+ * @param {number|string} remainOn1kgBasis - `remain` as the printer reports it
+ * @param {number|string} trayWeight - the spool's real filament weight in grams
+ * @param {string|null} trayType - `tray_type`, needed to spot support material
+ * @returns {number|null} remaining percentage of the real spool, rounded, or
+ *   null when the printer reported no usable value
+ */
+export function correctRemainInt(remainOn1kgBasis, trayWeight, trayType = null) {
+    const remain = parseFloat(remainOn1kgBasis);
+    // Unknown in, unknown out. The AMS reports no percentage for the first
+    // seconds after a spool goes in, and every caller has to decide for itself
+    // what to do without a reading; none of them may treat it as 0.
+    if (!Number.isFinite(remain)) return null;
+
+    const weight = parseFloat(trayWeight);
+    const isSupportMaterial = typeof trayType === "string" && trayType.endsWith("-S");
+
+    if (weight < 1000 && !isSupportMaterial) {
+        const grams = (remain / 100) * 1000;
+        let percent = (grams / weight) * 100;
+        if (percent > 100) percent = 100;
+        if (percent < 0) percent = 0;
+        return Math.round(percent);
+    }
+    return Math.round(remain);
+}

--- a/src/ams.js
+++ b/src/ams.js
@@ -1,6 +1,6 @@
 import { settings, legacyMode } from "./settings.js";
 import { toClientSpool } from "./uispool.js";
-import { slotColors } from "./utils.js";
+import { slotColors, filamentColors } from "./utils.js";
 import { consumptionKey, normColor } from "./gcode.js";
 
 /**
@@ -167,38 +167,11 @@ export function hasTrayDataChanged(nextTrayData, lastTrayData) {
  * Converts the AMS remain percentage into a percentage of the spool's real
  * size.
  *
- * The AMS estimates the remaining filament against a 1 kg reference regardless
- * of the actual spool, so a full 250 g spool reports 25 %. Rescaling to the
- * real `tray_weight` gives the value a user expects to see, clamped to 0 to 100.
- *
- * @param {number|string} remainOn1kgBasis - `remain` as reported by the AMS
- * @param {number|string} trayWeight - the spool's real filament weight in grams
- * @param {string|null} trayType - `tray_type`, needed to spot support material
- * @returns {number|null} remaining percentage of the real spool, rounded, or
- *   null when the printer reported no usable value
+ * Defined in `public/shared.js`, because the dashboard shows the same
+ * percentage from the same payload, and re-exported here so that `mqtt.js` and
+ * `spoolman.js` keep importing it from the AMS module.
  */
-export function correctRemainInt(remainOn1kgBasis, trayWeight, trayType = null) {
-    const remain = parseFloat(remainOn1kgBasis);
-    // Unknown in, unknown out. Every caller has to decide for itself what to do
-    // without a reading; none of them may treat it as 0.
-    if (!Number.isFinite(remain)) return null;
-    const weight = parseFloat(trayWeight);
-
-    // Support/accessory material (tray_type suffix "-S", e.g. "PLA-S") is sold
-    // and measured at its real spool size, not estimated on a 1kg basis like
-    // regular color filament <1kg, so its remain% is already relative to the
-    // actual tray_weight and must not be rescaled.
-    const isSupportMaterial = typeof trayType === "string" && trayType.endsWith("-S");
-
-    if (weight < 1000 && !isSupportMaterial) {
-        let grams = (remain / 100) * 1000;
-        let percent = (grams / weight) * 100;
-        if (percent > 100) percent = 100;
-        if (percent < 0) percent = 0;
-        return Math.round(percent);
-    }
-    return Math.round(remain);
-}
+export { correctRemainInt } from "../public/shared.js";
 
 /**
  * The fields an empty AMS slot reports. Anything beyond these is filament data.
@@ -293,14 +266,14 @@ export function findExistingSpool(amsSpool, allSpools) {
         const materialMatches = spoolmanSpool.filament.material === amsSpool.tray_sub_brands;
         const tagMatches = tag === amsSpool.tray_uuid;
 
-        if (amsColors.length > 1) {
-            if (!spoolmanSpool.filament.multi_color_hexes) return false;
-            const filamentColors = spoolmanSpool.filament.multi_color_hexes.split(",").map(c => c.toLowerCase()).sort();
-            return materialMatches && JSON.stringify(filamentColors) === JSON.stringify(sortedAmsColors) && tagMatches;
-        }
+        // One comparison for both shapes. A count that differs is what keeps a
+        // multi colour record from matching a single colour slot on its first
+        // hex, which is the case the two separate branches here used to cover.
+        const spoolColors = filamentColors(spoolmanSpool.filament);
+        if (spoolColors.length !== amsColors.length) return false;
 
-        const colorHex = spoolmanSpool.filament.color_hex?.toLowerCase();
-        return materialMatches && colorHex === amsColors[0] && tagMatches;
+        return materialMatches && tagMatches
+            && JSON.stringify([...spoolColors].sort()) === JSON.stringify(sortedAmsColors);
     }) || null;
 }
 

--- a/src/gcode.js
+++ b/src/gcode.js
@@ -3,6 +3,7 @@ import AdmZip from "adm-zip";
 import { Writable } from "stream";
 
 import { EXTERNAL_SLOT, convertAMSandSlot } from "./utils.js";
+import { normColor } from "../public/shared.js";
 
 /**
  * TLS options for BambuLab's self-signed certificate. The printer presents a
@@ -88,11 +89,12 @@ export async function fetchSliceInfo(printer, jobName) {
 /**
  * Normalises a color to a bare 6-digit uppercase hex (no "#", no alpha) so
  * slice colors ("#000000") and AMS slot colors ("000000FF") compare equal.
+ *
+ * Defined in `public/shared.js`, because the dashboard normalises the same
+ * colors out of the same payloads, and re-exported here so that every caller
+ * keeps importing it from where the consumption keys are built.
  */
-export function normColor(c) {
-    if (!c) return "";
-    return String(c).replace(/^#/, "").slice(0, 6).toUpperCase();
-}
+export { normColor } from "../public/shared.js";
 
 /**
  * Identity of a filament for consumption matching: tray_info_idx alone is the

--- a/src/utils.js
+++ b/src/utils.js
@@ -80,27 +80,13 @@ export const EXTERNAL_SPOOL_ID = 255;
 export const EXTERNAL_SLOT = "External";
 
 /**
- * The colour set of an AMS slot as bare six digit lowercase hex.
+ * The colour set of an AMS slot as bare six digit lowercase hex, and the colour
+ * set of a Spoolman filament in the same shape.
  *
- * AMS colours carry a trailing alpha byte that no Spoolman or SpoolmanDB record
- * has, so every comparison has to drop it first. Reading `cols` rather than
- * `tray_color` is what makes a multi colour filament comparable at all: the
- * single field only ever holds the first colour.
- *
- * Order is the one the printer reported, because it is the order the colours
- * sit on the filament and the order the UI draws them in. Callers comparing
- * colour sets sort a copy; Spoolman and SpoolmanDB do not agree on an order.
- *
- * Lives here rather than in `ams.js` so that `uispool.js` can use it too.
- * `ams.js` imports `uispool.js`, so an export there would close an import
- * cycle between the two.
- *
- * @param {object} slot - an AMS slot, normalised or raw
- * @returns {string[]} the colours, possibly empty
+ * Both live in `public/shared.js`, because the dashboard draws the same swatches
+ * from the same payloads and used to answer this with a second implementation.
+ * Re-exported from here so that the callers in `ams.js`, `mappings.js` and
+ * `uispool.js` keep their import: `ams.js` imports `uispool.js`, so an export in
+ * `ams.js` itself would close an import cycle between the two.
  */
-export function slotColors(slot) {
-    const raw = Array.isArray(slot?.cols) && slot.cols.length ? slot.cols : [slot?.tray_color];
-    return raw
-        .filter(color => color && color !== "N/A")
-        .map(color => String(color).slice(0, 6).toLowerCase());
-}
+export { slotColors, filamentColors } from "../public/shared.js";

--- a/test/shared.test.js
+++ b/test/shared.test.js
@@ -1,0 +1,146 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+    normColor,
+    slotColors,
+    filamentColors,
+    correctRemainInt,
+} from "../public/shared.js";
+
+import * as utils from "../src/utils.js";
+import * as gcode from "../src/gcode.js";
+import * as ams from "../src/ams.js";
+
+const root = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
+
+/* ---- normColor ---- */
+
+test("normColor strips the leading # and any alpha byte", () => {
+    assert.equal(normColor("#00AE42"), "00AE42");   // slice format
+    assert.equal(normColor("00ae42ff"), "00AE42");  // AMS format
+});
+
+test("normColor turns every absent colour into the same empty string", () => {
+    assert.equal(normColor(null), "");
+    assert.equal(normColor(undefined), "");
+    assert.equal(normColor(""), "");
+});
+
+/* ---- slotColors ---- */
+
+test("slotColors reads the whole set from cols, in the printer's order", () => {
+    assert.deepEqual(
+        slotColors({ cols: ["8EC9E9FF", "E7C1D5FF"], tray_color: "8EC9E9FF" }),
+        ["8ec9e9", "e7c1d5"],
+    );
+});
+
+test("slotColors falls back to tray_color only when cols has nothing", () => {
+    assert.deepEqual(slotColors({ cols: [], tray_color: "00AE42FF" }), ["00ae42"]);
+    assert.deepEqual(slotColors({ tray_color: "00AE42FF" }), ["00ae42"]);
+});
+
+test("slotColors drops the N/A placeholder rather than treating it as a colour", () => {
+    // An occupied but unidentified slot reports this, and the dashboard used to
+    // build "#N/A" out of it and hand that to CSS as a background.
+    assert.deepEqual(slotColors({ cols: [], tray_color: "N/A" }), []);
+    assert.deepEqual(slotColors({ cols: ["N/A", "00AE42FF"] }), ["00ae42"]);
+});
+
+test("slotColors survives a slot that is not there at all", () => {
+    assert.deepEqual(slotColors(null), []);
+    assert.deepEqual(slotColors({}), []);
+});
+
+/* ---- filamentColors ---- */
+
+test("filamentColors reads a multi colour record as the whole set", () => {
+    assert.deepEqual(
+        filamentColors({ multi_color_hexes: "8EC9E9,E7C1D5" }),
+        ["8ec9e9", "e7c1d5"],
+    );
+});
+
+test("filamentColors ignores an empty entry from a trailing separator", () => {
+    assert.deepEqual(filamentColors({ multi_color_hexes: "8EC9E9,E7C1D5," }), ["8ec9e9", "e7c1d5"]);
+});
+
+test("filamentColors reads a single colour record as a set of one", () => {
+    assert.deepEqual(filamentColors({ color_hex: "00AE42" }), ["00ae42"]);
+    assert.deepEqual(filamentColors({ color_hex: "#00AE42" }), ["00ae42"]);
+});
+
+test("filamentColors says nothing about a filament that carries no colour", () => {
+    assert.deepEqual(filamentColors({}), []);
+    assert.deepEqual(filamentColors(null), []);
+});
+
+test("a slot and the filament of its spool compare directly", () => {
+    // The point of the two living in one file: both sides lowercase, both drop
+    // the alpha byte, so a caller can compare the sorted sets without knowing
+    // which side produced which.
+    const slot = { cols: ["8EC9E9FF", "E7C1D5FF"] };
+    const filament = { multi_color_hexes: "e7c1d5,8ec9e9" };
+
+    assert.deepEqual(
+        [...slotColors(slot)].sort(),
+        [...filamentColors(filament)].sort(),
+    );
+});
+
+/* ---- correctRemainInt ---- */
+
+test("correctRemainInt passes a full size spool through unchanged", () => {
+    assert.equal(correctRemainInt(63, 1000, "PLA"), 63);
+});
+
+test("correctRemainInt rescales a spool smaller than 1kg to its real size", () => {
+    // 25% on a 1kg basis is a full 250g spool.
+    assert.equal(correctRemainInt(25, 250, "PLA"), 100);
+    assert.equal(correctRemainInt(10, 500, "PLA"), 20);
+});
+
+test("correctRemainInt leaves support material alone, whatever its size", () => {
+    // Support material is measured against its own spool already.
+    assert.equal(correctRemainInt(40, 500, "PLA-S"), 40);
+});
+
+test("correctRemainInt reports no reading rather than an empty spool", () => {
+    // The AMS sends nothing for the first seconds after a spool goes in, and
+    // 0% would read as an empty spool on the dashboard.
+    assert.equal(correctRemainInt(null, 1000, "PLA"), null);
+    assert.equal(correctRemainInt("", 1000, "PLA"), null);
+    assert.equal(correctRemainInt("not a number", 1000, "PLA"), null);
+});
+
+test("correctRemainInt clamps a reading that scales past the ends", () => {
+    assert.equal(correctRemainInt(120, 500, "PLA"), 100);
+    assert.equal(correctRemainInt(-5, 500, "PLA"), 0);
+});
+
+/* ---- one implementation, not two ---- */
+
+test("the server re-exports these rather than keeping a copy", () => {
+    // Identity, not behaviour: a second implementation that happens to agree
+    // today is exactly what this file exists to prevent.
+    assert.equal(utils.slotColors, slotColors);
+    assert.equal(utils.filamentColors, filamentColors);
+    assert.equal(gcode.normColor, normColor);
+    assert.equal(ams.correctRemainInt, correctRemainInt);
+});
+
+test("the dashboard imports them rather than keeping a copy", () => {
+    // public/ has no module loader in the tests, so this reads the file. The
+    // four names below were a second implementation until they were not, and a
+    // new one would go unnoticed for as long as the last one did.
+    const frontend = fs.readFileSync(path.join(root, "public", "frontend.js"), "utf8");
+
+    assert.match(frontend, /import\s*\{[^}]*\}\s*from\s*"\.\/shared\.js"/);
+    for (const gone of ["normColorJS", "slotColorsJS", "filamentColorsJS", "correctRemainIntJS"]) {
+        assert.equal(frontend.includes(gone), false, `${gone} is back in public/frontend.js`);
+    }
+});

--- a/test/supervisor.test.js
+++ b/test/supervisor.test.js
@@ -45,8 +45,11 @@ function runSupervisor(env, { signalAfterMs } = {}) {
     fs.copySync(path.join(root, "entrypoint.js"), path.join(dir, "entrypoint.js"));
     fs.copySync(path.join(here, "fixtures", "exiting-service.js"), path.join(dir, "starting.js"));
     // The whole src directory, so this does not break every time entrypoint.js
-    // imports one more module from it.
+    // imports one more module from it, and public/ with it: `src/utils.js` and
+    // `src/gcode.js` import `public/shared.js`, the one implementation the
+    // dashboard and the server share.
     fs.copySync(path.join(root, "src"), path.join(dir, "src"));
+    fs.copySync(path.join(root, "public"), path.join(dir, "public"));
 
     return new Promise(resolve => {
         const child = fork(path.join(dir, "entrypoint.js"), [], {


### PR DESCRIPTION
Four functions in `public/frontend.js` were a second implementation of rules the server already had: `normColorJS`, `slotColorsJS`, `filamentColorsJS` and `correctRemainIntJS`. They now live once, in `public/shared.js`, imported by both halves.

## Why

The drift that had already happened is the argument for it. `slotColors` drops the `"N/A"` an unidentified slot reports; the frontend copy did not, and turned the placeholder into a colour, so a slot holding a spool the printer cannot identify handed `#N/A` to CSS as a background.

This is the last piece of the same theme as #90, which moved the consumption match to the server after both defects fixed at the end of #89 turned out to sit in the browser's copy of it.

## Where the file lives

Under `public/`, because that is the half with the constraint: no build step, no dependencies, served straight from disk, so a browser has to load it as it is. The server has no such limit and imports it from there, which is why the arrow points one way and there is nothing to keep in step.

`public/index.html` loads `frontend.js` as a module, which is what makes the import possible. `menu.js` stays a classic script and `frontend.js` still calls `initMenubar` as a global, because modules run after classic scripts and before `DOMContentLoaded`. No build step, no bundler, no framework.

## Tests

`test/shared.test.js` is the first coverage anything under `public/` has had. It asserts the arrangement as well as the behaviour: that the server re-exports those functions rather than keeping a copy, and that `public/frontend.js` still imports them. A future second implementation fails a test rather than waiting for a user to notice.

`test/supervisor.test.js` copies `public/` alongside `src/` now, because `src/` imports across. 268 tests pass.

## Behaviour changes

- A slot holding a spool the printer cannot identify no longer draws a swatch out of the placeholder. This is the `"N/A"` case above.
- `findExistingSpool` compares one colour set instead of branching on the count, which is the same decision for both shapes. A Spoolman hex is cut to six digits there like every AMS colour, so a stored value carrying an alpha byte now compares rather than never matching. In practice Spoolman stores six.

## Verified

Against the mock printer and mock Spoolman in `scripts/test-server`, all 24 slots: the dashboard renders with no console error, multi colour swatches and their titles are unchanged, and the merge, create and assign dialogs all still build their colours.

## Also in here

A docs commit that drops the Home Assistant task from the open list and the matching note from the README. The add-on passes no environment variables; it drives the AMS monitoring toggle per printer and nothing else, so there was never anything for it to explain. It also records that armv7 keeps shipping on Node 22 past its end of life, and that the 1.3.0 version bump waits for the release actually being wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)