### PR TITLE
Bump the workflow actions off the deprecated Node.js 20 runtime

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -21,17 +21,21 @@ jobs:
       packages: write
 
     steps:
+      # The actions below run on the runner, not in the image: their Node is
+      # the runner's, and it is unrelated to the node:22-alpine the image is
+      # built from, which stays on 22 because linux/arm/v7 is published below
+      # and node:24-alpine has no armv7 build.
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up QEMU (multi-arch support)
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -90,7 +94,7 @@ jobs:
           echo "created=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> $GITHUB_OUTPUT
 
       - name: Build and push multi-arch image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           push: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,10 +32,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Node ${{ matrix.node }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: ${{ matrix.node }}
           cache: npm


### PR DESCRIPTION
Every action in both workflows targeted Node.js 20, which the runners now force onto Node.js 24 and annotate as deprecated on each run — the `v1.3.0-dev.5` publish carried that annotation. The current majors all declare `node24`, so the annotation goes away rather than being suppressed.

| | from | to |
|---|---|---|
| `actions/checkout` | v4 | v7 |
| `actions/setup-node` | v4 | v7 |
| `docker/setup-qemu-action` | v3 | v4 |
| `docker/setup-buildx-action` | v3 | v4 |
| `docker/login-action` | v3 | v4 |
| `docker/build-push-action` | v6 | v7 |

**This is the runner's Node, not the image's.** The container is still built from `node:22-alpine`, because `linux/arm/v7` is a published platform and `node:24-alpine` has no armv7 build. The two are easy to confuse, so the publish workflow now says so where the platform list is.

**Nothing the majors removed is used here:**

- `build-push-action` v7 drops `DOCKER_BUILD_NO_SUMMARY` and `DOCKER_BUILD_EXPORT_RETENTION_DAYS` — neither is set. `context`, `push`, `platforms`, `tags`, `labels`, `cache-from` and `cache-to` are unchanged.
- `setup-buildx-action` v4 drops deprecated inputs — it is called without any.
- `checkout` is called with no inputs at all.
- `setup-node` v6 limited automatic caching to npm, which is the cache this repository asks for.

The remaining change in all of them is the runtime and the switch to ESM. They need Actions Runner v2.327.1, which the GitHub-hosted runners are past.

The test workflow verifies itself on this PR. The publish workflow cannot be tried before a tag: it runs on tag pushes only, and a manual run aborts on its own `GITHUB_REF_TYPE` check. Its next real run is the next version tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
