### PR TITLE
fix: the spool location follows the AMS slot the spool is really in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,13 @@ Version 1.3.0-dev.5
       - A manufacturer created from the create-spool form carries what the catalogue knows about it, its external id and the weight of its empty spool, instead of its name alone, and nothing but the name when the name was typed over
       - "None configured" in the printer menu is readable in dark mode. It was the one entry left out of the dark rule that colours the menu text, so it was near black on a dark background
       - Seven routes answered without the ok field the Web UI reads, so a failure they reported was seen as neither success nor error
+      - The Spoolman location of a spool follows the AMS slot it is really in. SET_LOCATION was written from two places under two different conditions, and cleared from a third that checked nothing, so most of the mechanism did not work:
+         - Assigning a spool wrote no location at all and unassigning cleared none, so a spool the printer cannot identify never got a location, and one that was unassigned kept naming the slot it had left for good. Both endpoints write it now, and reassigning a slot moves the location from the old spool to the new one
+         - A spool created or merged by the automatic mode got no location either: the only write happened when a slot's filament identity changed, which is exactly what it does not do on the update after the spool was created. The location is now written whenever it does not already say what the slot says, which also corrects one that was changed in Spoolman by hand
+         - A location the user set themselves is no longer wiped. Every spool that left a slot was patched with an empty location, "Shelf A" included, for no reason other than having been in an AMS once. Only a location naming this printer is cleared
+         - A spool moved between two slots keeps its location. The slot it entered wrote the new one and the slot it left cleared it again moments later, decided purely by which slot came first in the AMS report. The changes of an AMS update are collected and applied once at the end, so a spool that ends up in any slot is claimed by it and only a spool in none of them is released
+         - Renaming a printer rewrites the locations it had written, and removing a printer clears them, instead of leaving "OldName - A0" behind on spools nothing would ever recognise again
+         - Creating a spool for a 3rd party slot from the dialog stores the slot as its location when the field was cleared, rather than leaving it empty
    - Development:
       - The container image no longer carries the test server or the script that regenerates the filament profile table. Neither has anything to run in a container, and the scripts that do, debug.sh, mqtt.js and capture-trays.js, are still there
       - public/materials.js holds the Bambu Studio filament ids the AMS reports as tray_info_idx, each with the material its profile prints, plus the rule for which materials count as the same stuff
@@ -54,6 +61,8 @@ Version 1.3.0-dev.5
          - The four bugs above are what those copies were hiding: a field missing from one of them, a status read off the wrong object in five of them, a colour missing from one theme
       - styles.css names the role of a colour rather than its value. Every rule whose colour differs between the themes was written out a second time as a dark mode copy of itself, 70 rules of it, so a colour occurring in fifteen rules had to be found in thirty. 265 colour literals become 117, of which 85 are the palette, and 102 lines mentioning dark mode become 7, with the computed style of both themes unchanged
       - frontend.js is indented like the other 25 JavaScript files, four spaces throughout, where it mixed 1568 tab indented lines with 483 using spaces
+      - src/location.js is the single place that writes a Spoolman location. It was spread over three call sites in two files, one of them riding along in the legacy weight PATCH, which is what let the conditions drift apart
+         - test/location.test.js and test/routes.mappings.location.test.js cover the ownership rule, the slot move, the printer rename and removal, and the assign and unassign endpoints, against a throwaway Spoolman that records what was written
 
 -----------------------------------------------------------------------------------------------
 Version 1.3.0-dev.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,18 @@
 -----------------------------------------------------------------------------------------------
+Unreleased
+   - Fixes:
+      - The Spoolman location of a spool follows the AMS slot it is really in. SET_LOCATION was written from two places under two different conditions, and cleared from a third that checked nothing, so most of the mechanism did not work:
+         - Assigning a spool wrote no location at all and unassigning cleared none, so a spool the printer cannot identify never got a location, and one that was unassigned kept naming the slot it had left for good. Both endpoints write it now, and reassigning a slot moves the location from the old spool to the new one
+         - A spool created or merged by the automatic mode got no location either: the only write happened when a slot's filament identity changed, which is exactly what it does not do on the update after the spool was created. The location is now written whenever it does not already say what the slot says, which also corrects one that was changed in Spoolman by hand
+         - A location the user set themselves is no longer wiped. Every spool that left a slot was patched with an empty location, "Shelf A" included, for no reason other than having been in an AMS once. Only a location naming this printer is cleared
+         - A spool moved between two slots keeps its location. The slot it entered wrote the new one and the slot it left cleared it again moments later, decided purely by which slot came first in the AMS report. The changes of an AMS update are collected and applied once at the end, so a spool that ends up in any slot is claimed by it and only a spool in none of them is released
+         - Renaming a printer rewrites the locations it had written, and removing a printer clears them, instead of leaving "OldName - A0" behind on spools nothing would ever recognise again
+         - Creating a spool for a 3rd party slot from the dialog stores the slot as its location when the field was cleared, rather than leaving it empty
+   - Development:
+      - src/location.js is the single place that writes a Spoolman location. It was spread over three call sites in two files, one of them riding along in the legacy weight PATCH, which is what let the conditions drift apart
+         - test/location.test.js and test/routes.mappings.location.test.js cover the ownership rule, the slot move, the printer rename and removal, and the assign and unassign endpoints, against a throwaway Spoolman that records what was written
+
+-----------------------------------------------------------------------------------------------
 Version 1.3.0-dev.5
    - New Features:
       - Clicking the filament name of a slot opens a dialog with everything the printer and Spoolman hold about it
@@ -41,13 +55,6 @@ Version 1.3.0-dev.5
       - A manufacturer created from the create-spool form carries what the catalogue knows about it, its external id and the weight of its empty spool, instead of its name alone, and nothing but the name when the name was typed over
       - "None configured" in the printer menu is readable in dark mode. It was the one entry left out of the dark rule that colours the menu text, so it was near black on a dark background
       - Seven routes answered without the ok field the Web UI reads, so a failure they reported was seen as neither success nor error
-      - The Spoolman location of a spool follows the AMS slot it is really in. SET_LOCATION was written from two places under two different conditions, and cleared from a third that checked nothing, so most of the mechanism did not work:
-         - Assigning a spool wrote no location at all and unassigning cleared none, so a spool the printer cannot identify never got a location, and one that was unassigned kept naming the slot it had left for good. Both endpoints write it now, and reassigning a slot moves the location from the old spool to the new one
-         - A spool created or merged by the automatic mode got no location either: the only write happened when a slot's filament identity changed, which is exactly what it does not do on the update after the spool was created. The location is now written whenever it does not already say what the slot says, which also corrects one that was changed in Spoolman by hand
-         - A location the user set themselves is no longer wiped. Every spool that left a slot was patched with an empty location, "Shelf A" included, for no reason other than having been in an AMS once. Only a location naming this printer is cleared
-         - A spool moved between two slots keeps its location. The slot it entered wrote the new one and the slot it left cleared it again moments later, decided purely by which slot came first in the AMS report. The changes of an AMS update are collected and applied once at the end, so a spool that ends up in any slot is claimed by it and only a spool in none of them is released
-         - Renaming a printer rewrites the locations it had written, and removing a printer clears them, instead of leaving "OldName - A0" behind on spools nothing would ever recognise again
-         - Creating a spool for a 3rd party slot from the dialog stores the slot as its location when the field was cleared, rather than leaving it empty
    - Development:
       - The container image no longer carries the test server or the script that regenerates the filament profile table. Neither has anything to run in a container, and the scripts that do, debug.sh, mqtt.js and capture-trays.js, are still there
       - public/materials.js holds the Bambu Studio filament ids the AMS reports as tray_info_idx, each with the material its profile prints, plus the rule for which materials count as the same stuff
@@ -61,8 +68,6 @@ Version 1.3.0-dev.5
          - The four bugs above are what those copies were hiding: a field missing from one of them, a status read off the wrong object in five of them, a colour missing from one theme
       - styles.css names the role of a colour rather than its value. Every rule whose colour differs between the themes was written out a second time as a dark mode copy of itself, 70 rules of it, so a colour occurring in fifteen rules had to be found in thirty. 265 colour literals become 117, of which 85 are the palette, and 102 lines mentioning dark mode become 7, with the computed style of both themes unchanged
       - frontend.js is indented like the other 25 JavaScript files, four spaces throughout, where it mixed 1568 tab indented lines with 483 using spaces
-      - src/location.js is the single place that writes a Spoolman location. It was spread over three call sites in two files, one of them riding along in the legacy weight PATCH, which is what let the conditions drift apart
-         - test/location.test.js and test/routes.mappings.location.test.js cover the ownership rule, the slot move, the printer rename and removal, and the assign and unassign endpoints, against a throwaway Spoolman that records what was written
 
 -----------------------------------------------------------------------------------------------
 Version 1.3.0-dev.4

--- a/src/location.js
+++ b/src/location.js
@@ -1,0 +1,218 @@
+import { settings } from "./settings.js";
+import { patchSpoolLocation, getSpoolmanSpool } from "./spoolman.js";
+
+/**
+ * The Spoolman location of a spool sitting in an AMS slot.
+ *
+ * Everything that writes a location goes through this, so the string the
+ * service writes and the one the "new spool" dialog suggests cannot drift
+ * apart. The dialog builds the same `${printer} - ${slot}` in
+ * `public/frontend.js`.
+ *
+ * @param {string} printerName - the printer's display name
+ * @param {string} amsId - slot label, e.g. "A0", "HT-A" or "External"
+ * @returns {string} the location to store in Spoolman
+ */
+export function slotLocation(printerName, amsId) {
+    return `${printerName} - ${amsId}`;
+}
+
+/**
+ * Whether a stored location was written by this service for this printer.
+ *
+ * The clearing paths used to patch an empty string onto any spool that left a
+ * slot, which wiped locations the user had set by hand ("Shelf A") for no
+ * reason other than the spool having been in an AMS once. A location is only
+ * ours to clear when it names this printer, so anything else survives.
+ *
+ * The slot part is not checked: a spool moved from A0 to A1 carries
+ * `Printer - A0` until the new slot is written, and that is still ours.
+ *
+ * @param {string|null|undefined} location - the spool's current location
+ * @param {string} printerName - the printer whose slot released the spool
+ * @returns {boolean} whether the location may be cleared
+ */
+export function ownsLocation(location, printerName) {
+    if (!location || !printerName) return false;
+    return location.startsWith(`${printerName} - `);
+}
+
+/**
+ * Writes a slot's location onto a spool, unless it already says that.
+ *
+ * Skipping the equal case matters: this is called from every AMS update, and
+ * Spoolman would otherwise see a PATCH per slot per update for a shelf full of
+ * spools that never moved.
+ *
+ * Failures are logged and swallowed. A location is a convenience, and losing
+ * it must not abort the slot processing that carries the weights.
+ *
+ * @param {object} printer - the printer runtime object
+ * @param {string} amsId - slot label
+ * @param {object|null} spool - the Spoolman spool now in the slot
+ * @returns {Promise<boolean>} whether a write happened
+ */
+export async function claimSlotLocation(printer, amsId, spool) {
+    if (!settings.SET_LOCATION || !spool?.id) return false;
+
+    const target = slotLocation(printer.name, amsId);
+    if (spool.location === target) return false;
+
+    try {
+        await patchSpoolLocation(spool.id, target);
+        // The record the caller holds is reused for the rest of this update and
+        // cached as `printer.spoolData`, so it has to carry what was written.
+        spool.location = target;
+        console.log(printer.name, printer.logFilePath, `    Set location "${target}" for Spool-ID ${spool.id}`);
+        return true;
+    } catch (err) {
+        console.error(printer.name, printer.logFilePath, `    Failed to set location for Spool-ID ${spool.id}:`, err.message);
+        return false;
+    }
+}
+
+/**
+ * Clears a spool's location when it left a slot of this printer.
+ *
+ * A spool whose location points somewhere else is left alone, see
+ * `ownsLocation()`.
+ *
+ * @param {object} printer - the printer runtime object
+ * @param {object|null} spool - the Spoolman spool that left the slot
+ * @returns {Promise<boolean>} whether a write happened
+ */
+export async function releaseSlotLocation(printer, spool) {
+    if (!settings.SET_LOCATION || !spool?.id) return false;
+    if (!ownsLocation(spool.location, printer.name)) return false;
+
+    try {
+        await patchSpoolLocation(spool.id, "");
+        spool.location = "";
+        console.log(printer.name, printer.logFilePath, `    Cleared location for Spool-ID ${spool.id}`);
+        return true;
+    } catch (err) {
+        console.error(printer.name, printer.logFilePath, `    Failed to clear location for Spool-ID ${spool.id}:`, err.message);
+        return false;
+    }
+}
+
+/**
+ * Collects the location changes of one AMS update and applies them at the end.
+ *
+ * Writing them as the slots are walked was wrong for the case a spool changes
+ * slot: moving one from A1 to A0 wrote `Printer - A0` while A0 was processed
+ * and then, one slot later, cleared it again, because A1 saw the spool it used
+ * to hold gone and had no way to know it had just reappeared elsewhere. Slot
+ * order decided whether a move kept its location or lost it.
+ *
+ * Deferring makes the whole AMS the unit of decision instead of the slot: a
+ * spool that ends up in any slot is claimed by it, and only a spool in none of
+ * them is released. Claims run before releases so a Spoolman write can never
+ * leave a spool that is physically in the AMS without a location.
+ *
+ * @param {object} printer - the printer runtime object
+ * @returns {{claim: Function, release: Function, flush: Function}}
+ */
+export function createLocationSync(printer) {
+    // Keyed by spool id: the same spool cannot be in two slots, but the AMS can
+    // report it that way for an update while a move is in flight, and the last
+    // slot to claim it is the one that wins.
+    const claims = new Map();
+    const releases = new Map();
+
+    return {
+        /** Records that `spool` occupies `amsId`. Null spools are ignored. */
+        claim(amsId, spool) {
+            if (!spool?.id) return;
+            claims.set(spool.id, { amsId, spool });
+            releases.delete(spool.id);
+        },
+
+        /**
+         * Records that `spool` used to occupy a slot that no longer holds it.
+         * Ignored when the same spool is claimed by another slot, now or later
+         * in this update.
+         */
+        release(spool) {
+            if (!spool?.id || claims.has(spool.id)) return;
+            releases.set(spool.id, spool);
+        },
+
+        /** Applies the collected changes. Claims first, then releases. */
+        async flush() {
+            if (!settings.SET_LOCATION) return;
+
+            for (const { amsId, spool } of claims.values()) {
+                await claimSlotLocation(printer, amsId, spool);
+            }
+            for (const spool of releases.values()) {
+                await releaseSlotLocation(printer, spool);
+            }
+        },
+    };
+}
+
+/**
+ * The spools this printer's slots currently hold, as Spoolman has them now.
+ *
+ * Only the slots with a real link count: a merge or creation candidate found by
+ * filament match sits in the cached slot data too, but it is not in the AMS and
+ * never got a location from us.
+ *
+ * The records are refetched rather than taken from the cache, because both
+ * callers decide what to write from the location Spoolman holds right now.
+ *
+ * @param {object} printer - the printer runtime object
+ * @returns {Promise<Array<{amsId: string, spool: object}>>}
+ */
+async function occupiedSlots(printer) {
+    const slots = [];
+
+    for (const uiSpool of printer.spoolData || []) {
+        if (!uiSpool.connectedViaTag && !uiSpool.connectedViaMapping) continue;
+        const id = uiSpool.existingSpool?.id;
+        if (!id) continue;
+
+        const spool = await getSpoolmanSpool(id).catch(() => uiSpool.existingSpool);
+        slots.push({ amsId: uiSpool.amsId, spool });
+    }
+
+    return slots;
+}
+
+/**
+ * Clears the locations of every spool in this printer's slots.
+ *
+ * Called before a printer is removed. The ownership check matches on the
+ * printer's name, so once the printer is gone its locations are
+ * indistinguishable from ones the user set by hand and would stay behind
+ * forever.
+ *
+ * @param {object} printer - the printer runtime object
+ */
+export async function releasePrinterLocations(printer) {
+    if (!settings.SET_LOCATION) return;
+
+    for (const { spool } of await occupiedSlots(printer)) {
+        await releaseSlotLocation(printer, spool);
+    }
+}
+
+/**
+ * Rewrites the locations of this printer's spools after it was renamed.
+ *
+ * Without this the spools keep naming the old printer, which is both wrong on
+ * the shelf and invisible to `ownsLocation()`, so nothing would ever clear them
+ * again either.
+ *
+ * @param {object} printer - the printer runtime object, already renamed
+ * @param {string} previousName - the name the locations were written with
+ */
+export async function renamePrinterLocations(printer, previousName) {
+    if (!settings.SET_LOCATION) return;
+
+    for (const { amsId, spool } of await occupiedSlots(printer)) {
+        if (!ownsLocation(spool?.location, previousName)) continue;
+        await claimSlotLocation(printer, amsId, spool);
+    }
+}

--- a/src/mqtt.js
+++ b/src/mqtt.js
@@ -14,12 +14,12 @@ import {
     createFilamentAndSpool,
     mergeSpool,
     patchSpoolWeight,
-    patchSpoolLocation,
     useSpoolWeight,
     logSpoolmanFailure,
 } from "./spoolman.js";
 import { fetchSliceInfo, calcFullConsumption, calcPartialConsumption, resolveSliceSlots, orderedAmsSlots, decodePrintMapping } from "./gcode.js";
 import { getMapping, clearMapping } from "./mappings.js";
+import { createLocationSync } from "./location.js";
 import {
     processData,
     extractComparableTrayData,
@@ -389,6 +389,11 @@ async function handleMqttMessage(printer, topic, message) {
                             );
                             printer.spoolData = [];
 
+                            // Collected across every slot and applied below, so a
+                            // spool moved between two slots is not cleared by the
+                            // slot it left after the slot it entered claimed it.
+                            const locationSync = createLocationSync(printer);
+
                             for (const ams of processedAmsData) {
                                 if (!Array.isArray(ams.tray)) {
                                     console.debug(printer.name, printer.logFilePath, "Data from Slots are not valid");
@@ -396,7 +401,7 @@ async function handleMqttMessage(printer, topic, message) {
                                 }
 
                                 for (const slot of ams.tray) {
-                                    const mutated = await processSlot(printer, ams, slot, spools, externalFilaments, internalFilaments, prevByAmsId, currentTime);
+                                    const mutated = await processSlot(printer, ams, slot, spools, externalFilaments, internalFilaments, prevByAmsId, currentTime, locationSync);
 
                                     // Only refetch when this slot actually created/merged a
                                     // spool or filament in Spoolman. Otherwise the cached
@@ -409,6 +414,8 @@ async function handleMqttMessage(printer, topic, message) {
                                     }
                                 }
                             }
+
+                            await locationSync.flush();
 
                             state.lastSpoolData = spools;
                             printer.lastMqttAmsUpdate = new Date();
@@ -460,21 +467,24 @@ async function handleMqttMessage(printer, topic, message) {
 }
 
 /**
- * Clears the Spoolman location of the spool that used to sit in this slot when
- * a different one is there now, so a removed spool does not keep claiming an
- * AMS slot as its location. No-op unless the location setting is on.
+ * Hands the location sync the spool a slot used to hold, so it is released
+ * unless some slot of this AMS update claims it again.
+ *
+ * The cached record is only used for its id: its `location` is whatever
+ * Spoolman said when the record was fetched, and the ownership check that
+ * decides whether the location may be cleared has to read the current one.
+ *
+ * @param {object} locationSync - the collector for this AMS update
+ * @param {string} amsId - slot label
+ * @param {object} prevByAmsId - the previous UI spools, keyed by slot label
+ * @param {object[]} spools - Spoolman spools, as fetched for this AMS update
  */
-async function clearLocationIfSpoolChanged(printer, amsId, currentSpoolId, prevByAmsId) {
-    if (!settings.SET_LOCATION) return;
+function releasePreviousSpool(locationSync, amsId, prevByAmsId, spools) {
     const prevSpoolId = prevByAmsId[amsId]?.existingSpool?.id ?? null;
-    if (prevSpoolId && prevSpoolId !== currentSpoolId) {
-        try {
-            await patchSpoolLocation(prevSpoolId, "");
-            console.log(printer.name, printer.logFilePath, `    Cleared location for Spool-ID ${prevSpoolId} (removed from ${amsId})`);
-        } catch (err) {
-            console.error(printer.name, printer.logFilePath, `    Failed to clear location for Spool-ID ${prevSpoolId}:`, err.message);
-        }
-    }
+    if (!prevSpoolId) return;
+
+    const current = (spools || []).find(s => s.id === prevSpoolId);
+    locationSync.release(current ?? prevByAmsId[amsId].existingSpool);
 }
 
 // How many AMS updates a slot may wait for its remain reading before a spool is
@@ -542,10 +552,12 @@ export function waitedLongEnoughForRemain(printer, amsId, slot) {
  * @param {object[]} internalFilaments - filaments in this Spoolman instance
  * @param {object} prevByAmsId - the previous UI spools, keyed by slot label
  * @param {Date} currentTime - timestamp shared across this AMS update
+ * @param {object} locationSync - collects the location changes of this update,
+ *   which are applied once every slot has been seen
  * @returns {Promise<boolean>} whether Spoolman was mutated, which tells the
  *   caller its cached lists are stale and have to be refetched
  */
-async function processSlot(printer, ams, slot, spools, externalFilaments, internalFilaments, prevByAmsId, currentTime) {
+async function processSlot(printer, ams, slot, spools, externalFilaments, internalFilaments, prevByAmsId, currentTime, locationSync) {
     const amsId = convertAMSandSlot(ams.id, slot.id);
     const validSlot = Object.keys(slot).length > 6;
 
@@ -564,7 +576,7 @@ async function processSlot(printer, ams, slot, spools, externalFilaments, intern
             ? "No Data found in Slots (empty slot with N/A values)"
             : "No Data found in Slots");
         const newUiSpool = buildEmptySpool(printer, amsId, slot);
-        await clearLocationIfSpoolChanged(printer, amsId, null, prevByAmsId);
+        releasePreviousSpool(locationSync, amsId, prevByAmsId, spools);
         pushSlotUpdate(printer, newUiSpool, prevByAmsId);
         return false;
     }
@@ -587,7 +599,11 @@ async function processSlot(printer, ams, slot, spools, externalFilaments, intern
         // read-only exactly as it was before assignments existed.
         const mappedSpool = legacyMode() ? null : resolveMappedSpool(printer, amsId, slot, spools);
         const newUiSpool = buildThirdPartySpool(printer, amsId, slot, mappedSpool);
-        await clearLocationIfSpoolChanged(printer, amsId, mappedSpool?.id ?? null, prevByAmsId);
+        // The assignment is the only link a chipless spool has, so it is also
+        // the only thing that can give it a location. Nothing did before, which
+        // is why an assigned 3rd party spool never got one at all.
+        locationSync.claim(amsId, mappedSpool);
+        releasePreviousSpool(locationSync, amsId, prevByAmsId, spools);
         if (hasSpoolUiChanged(newUiSpool, prevByAmsId[newUiSpool.amsId])) {
             broadcastSlotUpdate(printer.id, newUiSpool);
             // No uuid to print, so the line says what the slot is instead: the
@@ -660,13 +676,12 @@ async function processSlot(printer, ams, slot, spools, externalFilaments, intern
                     }
 
                     const remainingWeight = Math.round((currRemain / 100) * slot.tray_weight);
-                    const newLocation = settings.SET_LOCATION ? `${printer.name} - ${amsId}` : null;
 
                     console.debug(printer.name, printer.logFilePath, "    Sending PATCH request to:", `${spoolmanUrl()}/api/v1/spool/${spool.id}`);
-                    console.debug(printer.name, printer.logFilePath, "    Payload:", JSON.stringify({ remaining_weight: remainingWeight, last_used: currentTime, ...(newLocation && { location: newLocation }) }));
+                    console.debug(printer.name, printer.logFilePath, "    Payload:", JSON.stringify({ remaining_weight: remainingWeight, last_used: currentTime }));
 
                     try {
-                        await patchSpoolWeight(spool.id, remainingWeight, currentTime, newLocation);
+                        await patchSpoolWeight(spool.id, remainingWeight, currentTime);
                         console.log(printer.name, printer.logFilePath, ` [${amsId}] ${slot.tray_sub_brands} ${slot.tray_color} (${currRemain}%) [[ ${slot.tray_uuid} ]]`);
                         console.log(printer.name, printer.logFilePath, `    Updated Spool-ID ${spool.id} => ${spool.filament.name}`);
                     } catch (err) {
@@ -676,18 +691,12 @@ async function processSlot(printer, ams, slot, spools, externalFilaments, intern
                     printer.lastUpdateTime = currentTime;
                 } else {
                     // Default: weight is tracked from the sliced G-code on print
-                    // completion (see handlePrintStateChange). Here we only log /
-                    // sync location on real identity changes, not on remain ticks.
+                    // completion (see handlePrintStateChange). Nothing is written
+                    // here, and the line is held back on remain ticks so a spool
+                    // that only reports a new percentage does not repeat itself.
+                    // The location is claimed once for the whole update below.
                     if (meaningfulChange) {
                         console.log(printer.name, printer.logFilePath, ` [${amsId}] ${slot.tray_sub_brands} ${slot.tray_color} [[ ${slot.tray_uuid} ]] => Spool-ID ${spool.id} (G-code mode)`);
-
-                        if (settings.SET_LOCATION) {
-                            try {
-                                await patchSpoolLocation(spool.id, `${printer.name} - ${amsId}`);
-                            } catch (err) {
-                                console.error(printer.name, printer.logFilePath, "   Location update failed:", err.message);
-                            }
-                        }
                     }
                 }
 
@@ -815,7 +824,11 @@ async function processSlot(printer, ams, slot, spools, externalFilaments, intern
         enableButton = "true";
     }
 
-    await clearLocationIfSpoolChanged(printer, amsId, existingSpool?.id ?? null, prevByAmsId);
+    // Only a spool this slot is really connected to may claim it. `existingSpool`
+    // can also be a mere merge/creation candidate found by filament match, which
+    // is not in the AMS at all and must not be given its location.
+    if (found || mappedSpool) locationSync.claim(amsId, existingSpool);
+    releasePreviousSpool(locationSync, amsId, prevByAmsId, spools);
 
     const newUiSpool = {
         amsId,

--- a/src/routes.js
+++ b/src/routes.js
@@ -36,6 +36,13 @@ import { fetchSliceInfo, calcFullConsumption, calcPartialConsumption, testFtpsCo
 import { consumptionCandidate, matchConsumption } from "./ams.js";
 import { setupMqtt, closeMqtt, broadcastSlotUpdate, broadcastSSE, testMqttConnection, ACTIVE_STATES } from "./mqtt.js";
 import { getMappings, setMapping, clearMapping, clearPrinterMappings } from "./mappings.js";
+import {
+    claimSlotLocation,
+    releaseSlotLocation,
+    releasePrinterLocations,
+    renamePrinterLocations,
+    slotLocation,
+} from "./location.js";
 
 /**
  * Looks up a printer, answering with a 404 and returning null when there is
@@ -692,6 +699,17 @@ export function registerRoutes(app, printers) {
             if (!spool) return res.status(404).json({ ok: false, error: `Spool ${spoolId} not found in Spoolman` });
 
             const mapping = setMapping(printerId, amsId, spoolId, uiSpool.slot);
+
+            // The spool that was assigned here up to now leaves the slot, so it
+            // gives its location back before the new one takes it. Waiting for
+            // the next AMS update was not an option: by then the cached slot
+            // already names the new spool and the old one is nowhere to be found.
+            const previous = uiSpool.existingSpool;
+            if (previous && previous.id !== spoolId) {
+                await releaseSlotLocation(printer, spools.find(s => s.id === previous.id) ?? previous);
+            }
+            await claimSlotLocation(printer, amsId, spool);
+
             applyMappingToUiSpool(printer, uiSpool, spool);
             console.log(printer.name, printer.logFilePath, `[Mapping] ${amsId} assigned to Spoolman spool ${spoolId} (${spool.filament?.name ?? "?"})`);
 
@@ -827,7 +845,12 @@ export function registerRoutes(app, printers) {
                 first_used: Date.now(),
                 initial_weight: numberOrNull(spool.initialWeight),
                 remaining_weight: numberOrNull(spool.remainingWeight),
-                location: spool.location?.trim() || null,
+                // The dialog prefills the slot, but a user who clears the field
+                // still ends up with a spool that is demonstrably in this slot,
+                // so the slot is what it gets. Only with the setting on: with it
+                // off nothing else writes a location either.
+                location: spool.location?.trim()
+                    || (settings.SET_LOCATION ? slotLocation(printer.name, amsId) : null),
                 lot_nr: spool.lotNr?.trim() || null,
                 comment: spool.comment?.trim() || null,
             };
@@ -847,16 +870,29 @@ export function registerRoutes(app, printers) {
         }
     });
 
-    app.delete("/api/mappings/:printerId/:amsId", (req, res) => {
+    app.delete("/api/mappings/:printerId/:amsId", async (req, res) => {
         if (rejectInLegacyMode(res)) return;
 
         const { printerId, amsId } = req.params;
         const printer = resolvePrinter(printerId, printers, res);
         if (!printer) return;
 
+        const uiSpool = (printer.spoolData || []).find(s => s.amsId === amsId);
+        // Read before the mapping goes, and before the cached slot is cleared:
+        // afterwards nothing says which spool used to sit here, which is why an
+        // unassigned spool kept naming this slot as its location forever.
+        const assigned = uiSpool?.connectedViaMapping ? uiSpool.existingSpool : null;
+
         const existed = clearMapping(printerId, amsId);
 
-        const uiSpool = (printer.spoolData || []).find(s => s.amsId === amsId);
+        if (assigned) {
+            // Straight from Spoolman rather than from the cache: the ownership
+            // check may only clear a location this service wrote, and the
+            // cached record carries whatever it said when it was fetched.
+            const current = await getSpoolmanSpool(assigned.id).catch(() => assigned);
+            await releaseSlotLocation(printer, current);
+        }
+
         if (uiSpool) applyMappingToUiSpool(printer, uiSpool, null);
         if (existed) console.log(printer.name, printer.logFilePath, `[Mapping] ${amsId} assignment removed`);
 
@@ -1002,9 +1038,13 @@ export function registerRoutes(app, printers) {
         res.json({ ok: true, printer: publicPrinter(result.printer) });
     });
 
-    app.put("/api/printers/:printerId", (req, res) => {
+    app.put("/api/printers/:printerId", async (req, res) => {
         const printer = resolvePrinter(req.params.printerId, printers, res);
         if (!printer) return;
+
+        // Read before the update, because the locations already in Spoolman
+        // carry this name and nothing would recognise them afterwards.
+        const previousName = printer.name;
 
         // Only an address or credential change drops the connection, a rename
         // does not, so only that needs the print in flight to be confirmed.
@@ -1018,6 +1058,10 @@ export function registerRoutes(app, printers) {
         if (!result.ok) {
             const status = result.error === "Printer not found" ? 404 : 400;
             return res.status(status).json({ ok: false, error: result.error });
+        }
+
+        if (result.printer.name !== previousName) {
+            await renamePrinterLocations(result.printer, previousName);
         }
 
         console.log(result.printer.name, result.printer.logFilePath, `[Printer] Updated ${result.printer.name} (${result.printer.id})`);
@@ -1035,7 +1079,7 @@ export function registerRoutes(app, printers) {
         res.json({ ok: true, printer: publicPrinter(result.printer), reconnected: result.reconnect });
     });
 
-    app.delete("/api/printers/:printerId", (req, res) => {
+    app.delete("/api/printers/:printerId", async (req, res) => {
         const printer = resolvePrinter(req.params.printerId, printers, res);
         if (!printer) return;
 
@@ -1045,6 +1089,11 @@ export function registerRoutes(app, printers) {
 
         printer.monitoringEnabled = false;
         disconnectPrinter(printer);
+
+        // Before the printer goes: its name is what the ownership check matches
+        // on, so once it is removed nothing can tell its locations apart from
+        // the ones a user set by hand.
+        await releasePrinterLocations(printer);
 
         const result = removePrinter(printer.id);
         if (!result.ok) return res.status(404).json({ ok: false, error: result.error });

--- a/src/spoolman.js
+++ b/src/spoolman.js
@@ -512,15 +512,18 @@ export async function mergeSpool(spoolData) {
  * Sets a spool's remaining weight directly. This is the legacy mode write path,
  * where the weight comes from the AMS RFID remain percentage.
  *
+ * The location used to ride along in this payload, which meant legacy mode and
+ * G-code mode wrote it from two different places under two different
+ * conditions. `src/location.js` owns it in both modes now.
+ *
  * @param {number} spoolId - Spoolman spool id
  * @param {number} remainingWeight - grams left on the spool
  * @param {string} lastUsed - ISO timestamp
- * @param {string|null} location - AMS slot label, only sent when the location setting is on
  */
-export async function patchSpoolWeight(spoolId, remainingWeight, lastUsed, location = null) {
-    const payload = { remaining_weight: remainingWeight, last_used: lastUsed };
-    if (location !== null) payload.location = location;
-    return got.patch(`${spoolmanUrl()}/api/v1/spool/${spoolId}`, { json: payload });
+export async function patchSpoolWeight(spoolId, remainingWeight, lastUsed) {
+    return got.patch(`${spoolmanUrl()}/api/v1/spool/${spoolId}`, {
+        json: { remaining_weight: remainingWeight, last_used: lastUsed },
+    });
 }
 
 /**

--- a/test/location.test.js
+++ b/test/location.test.js
@@ -1,0 +1,301 @@
+import test, { after, before, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import http from "node:http";
+
+// A throwaway Spoolman: every PATCH is recorded and answered, so the tests can
+// assert what was written rather than only what the helpers returned.
+const patches = [];
+const spools = new Map();
+
+const server = http.createServer((req, res) => {
+    const id = Number(req.url.split("/").pop());
+
+    if (req.method === "GET") {
+        const spool = spools.get(id);
+        res.writeHead(spool ? 200 : 404, { "content-type": "application/json" });
+        return res.end(JSON.stringify(spool ?? { detail: "not found" }));
+    }
+
+    let body = "";
+    req.on("data", chunk => { body += chunk; });
+    req.on("end", () => {
+        const payload = JSON.parse(body || "{}");
+        patches.push({ id, payload });
+
+        const spool = spools.get(id);
+        if (spool) Object.assign(spool, payload);
+
+        res.writeHead(200, { "content-type": "application/json" });
+        res.end(JSON.stringify(spool ?? { id, ...payload }));
+    });
+});
+
+await new Promise(resolve => server.listen(0, "127.0.0.1", resolve));
+
+const { settings } = await import("../src/settings.js");
+settings.SPOOLMAN_ENDPOINT = `http://127.0.0.1:${server.address().port}`;
+settings.SET_LOCATION = true;
+
+const {
+    slotLocation,
+    ownsLocation,
+    claimSlotLocation,
+    releaseSlotLocation,
+    createLocationSync,
+    releasePrinterLocations,
+    renamePrinterLocations,
+} = await import("../src/location.js");
+
+const printer = { id: "01P00A000000011", name: "Test Printer", logFilePath: null };
+
+/** Registers a spool with the fake Spoolman and returns the record. */
+function seed(id, location = null) {
+    const spool = { id, location, filament: { name: `spool ${id}` } };
+    spools.set(id, spool);
+    // A copy, so a test can hand the helpers a record that is stale in exactly
+    // the way the cached `printer.spoolData` is.
+    return { ...spool };
+}
+
+beforeEach(() => {
+    patches.length = 0;
+    spools.clear();
+    settings.SET_LOCATION = true;
+    printer.name = "Test Printer";
+    printer.spoolData = [];
+});
+
+after(() => new Promise(resolve => server.close(resolve)));
+
+// ---------------------------------------------------------------------------
+// The location string and who it belongs to
+// ---------------------------------------------------------------------------
+
+test("the location is the printer name and the slot label", () => {
+    assert.equal(slotLocation("X1C", "A0"), "X1C - A0");
+    assert.equal(slotLocation("X1C", "External"), "X1C - External");
+    assert.equal(slotLocation("X1C", "HT-A"), "X1C - HT-A");
+});
+
+test("a location this printer wrote is ours, whichever slot it names", () => {
+    assert.equal(ownsLocation("X1C - A0", "X1C"), true);
+    assert.equal(ownsLocation("X1C - HT-B", "X1C"), true);
+});
+
+test("a location the user set by hand is not ours", () => {
+    // The bug this guards: every spool that ever sat in an AMS used to have its
+    // location wiped on the way out, shelf or not.
+    assert.equal(ownsLocation("Shelf A", "X1C"), false);
+    assert.equal(ownsLocation("", "X1C"), false);
+    assert.equal(ownsLocation(null, "X1C"), false);
+});
+
+test("a location of a printer with a similar name is not ours", () => {
+    assert.equal(ownsLocation("P1S - A0", "P1"), false);
+    assert.equal(ownsLocation("P1 - A0", "P1S"), false);
+});
+
+// ---------------------------------------------------------------------------
+// Claiming and releasing one slot
+// ---------------------------------------------------------------------------
+
+test("claiming a slot writes the location", async () => {
+    const spool = seed(1);
+
+    assert.equal(await claimSlotLocation(printer, "A0", spool), true);
+    assert.deepEqual(patches, [{ id: 1, payload: { location: "Test Printer - A0" } }]);
+    // The caller's record is reused for the rest of the update, so it has to
+    // carry what was written.
+    assert.equal(spool.location, "Test Printer - A0");
+});
+
+test("claiming a slot that already says so writes nothing", async () => {
+    const spool = seed(1, "Test Printer - A0");
+
+    assert.equal(await claimSlotLocation(printer, "A0", spool), false);
+    assert.deepEqual(patches, []);
+});
+
+test("claiming corrects a location that was changed in Spoolman", async () => {
+    // Nothing used to reconcile this: the write only happened when the slot's
+    // filament identity changed, so a location edited in Spoolman stayed wrong.
+    const spool = seed(1, "Somewhere else");
+
+    assert.equal(await claimSlotLocation(printer, "A0", spool), true);
+    assert.equal(patches[0].payload.location, "Test Printer - A0");
+});
+
+test("releasing clears a location this printer wrote", async () => {
+    const spool = seed(1, "Test Printer - A0");
+
+    assert.equal(await releaseSlotLocation(printer, spool), true);
+    assert.deepEqual(patches, [{ id: 1, payload: { location: "" } }]);
+});
+
+test("releasing leaves a location the user set alone", async () => {
+    const spool = seed(1, "Shelf A");
+
+    assert.equal(await releaseSlotLocation(printer, spool), false);
+    assert.deepEqual(patches, []);
+    assert.equal(spools.get(1).location, "Shelf A");
+});
+
+test("releasing leaves another printer's location alone", async () => {
+    const spool = seed(1, "Other Printer - A0");
+
+    assert.equal(await releaseSlotLocation(printer, spool), false);
+    assert.deepEqual(patches, []);
+});
+
+test("nothing is written while the setting is off", async () => {
+    settings.SET_LOCATION = false;
+    const spool = seed(1, "Test Printer - A0");
+
+    assert.equal(await claimSlotLocation(printer, "A0", seed(2)), false);
+    assert.equal(await releaseSlotLocation(printer, spool), false);
+    assert.deepEqual(patches, []);
+});
+
+test("a slot without a spool writes nothing", async () => {
+    assert.equal(await claimSlotLocation(printer, "A0", null), false);
+    assert.equal(await releaseSlotLocation(printer, null), false);
+    assert.deepEqual(patches, []);
+});
+
+test("a failing Spoolman is logged, not thrown", async () => {
+    const unreachable = { ...printer };
+    const spool = { id: 999, location: "Test Printer - A0" };
+    spools.delete(999);
+
+    settings.SPOOLMAN_ENDPOINT = "http://127.0.0.1:1";
+    try {
+        assert.equal(await claimSlotLocation(unreachable, "A0", { id: 999 }), false);
+        assert.equal(await releaseSlotLocation(unreachable, spool), false);
+    } finally {
+        settings.SPOOLMAN_ENDPOINT = `http://127.0.0.1:${server.address().port}`;
+    }
+});
+
+// ---------------------------------------------------------------------------
+// One AMS update as a whole
+// ---------------------------------------------------------------------------
+
+test("a spool that changed slot keeps its location", async () => {
+    // The regression this exists for: A0 is processed before A1, so the slot the
+    // spool moved into wrote the new location and the slot it left cleared it
+    // again one slot later.
+    const spool = seed(1, "Test Printer - A1");
+    const sync = createLocationSync(printer);
+
+    sync.claim("A0", spool);   // it is here now
+    sync.release(spool);       // A1 reports it gone
+    await sync.flush();
+
+    assert.deepEqual(patches, [{ id: 1, payload: { location: "Test Printer - A0" } }]);
+});
+
+test("the slot order does not decide the outcome of a move", async () => {
+    const spool = seed(1, "Test Printer - A0");
+    const sync = createLocationSync(printer);
+
+    sync.release(spool);       // A0 reports it gone
+    sync.claim("A1", spool);   // it turns up in A1
+    await sync.flush();
+
+    assert.deepEqual(patches, [{ id: 1, payload: { location: "Test Printer - A1" } }]);
+});
+
+test("a spool taken out of the AMS is released", async () => {
+    const spool = seed(1, "Test Printer - A0");
+    const sync = createLocationSync(printer);
+
+    sync.release(spool);
+    await sync.flush();
+
+    assert.deepEqual(patches, [{ id: 1, payload: { location: "" } }]);
+});
+
+test("a slot whose spool was swapped releases the old one and claims the new", async () => {
+    const removed = seed(1, "Test Printer - A0");
+    const inserted = seed(2);
+    const sync = createLocationSync(printer);
+
+    sync.claim("A0", inserted);
+    sync.release(removed);
+    await sync.flush();
+
+    // Claims first: a spool that is physically in the AMS must never be left
+    // without a location, not even between two requests.
+    assert.deepEqual(patches, [
+        { id: 2, payload: { location: "Test Printer - A0" } },
+        { id: 1, payload: { location: "" } },
+    ]);
+});
+
+test("a flush writes nothing while the setting is off", async () => {
+    settings.SET_LOCATION = false;
+    const sync = createLocationSync(printer);
+
+    sync.claim("A0", seed(1));
+    sync.release(seed(2, "Test Printer - A1"));
+    await sync.flush();
+
+    assert.deepEqual(patches, []);
+});
+
+// ---------------------------------------------------------------------------
+// The printer itself changing
+// ---------------------------------------------------------------------------
+
+test("removing a printer gives its slots' locations back", async () => {
+    seed(1, "Test Printer - A0");
+    seed(2, "Shelf A");
+    printer.spoolData = [
+        { amsId: "A0", connectedViaTag: true, existingSpool: { id: 1 } },
+        { amsId: "A1", connectedViaMapping: true, existingSpool: { id: 2 } },
+    ];
+
+    await releasePrinterLocations(printer);
+
+    // Only the one this printer wrote. The hand-set shelf survives.
+    assert.deepEqual(patches, [{ id: 1, payload: { location: "" } }]);
+});
+
+test("removing a printer ignores slots that only hold a merge candidate", async () => {
+    seed(1, "Test Printer - A0");
+    printer.spoolData = [{ amsId: "A0", existingSpool: { id: 1 } }];
+
+    await releasePrinterLocations(printer);
+
+    assert.deepEqual(patches, []);
+});
+
+test("renaming a printer rewrites the locations it had written", async () => {
+    seed(1, "Old Name - A0");
+    seed(2, "Shelf A");
+    printer.spoolData = [
+        { amsId: "A0", connectedViaTag: true, existingSpool: { id: 1 } },
+        { amsId: "A1", connectedViaTag: true, existingSpool: { id: 2 } },
+    ];
+    printer.name = "New Name";
+
+    await renamePrinterLocations(printer, "Old Name");
+
+    assert.deepEqual(patches, [{ id: 1, payload: { location: "New Name - A0" } }]);
+});
+
+test("a rename reads the location from Spoolman, not from the cached slot", async () => {
+    // The cached record is whatever Spoolman said when it was fetched, and the
+    // decision depends on what it says now.
+    seed(1, "Old Name - A0");
+    printer.spoolData = [{
+        amsId: "A0",
+        connectedViaTag: true,
+        existingSpool: { id: 1, location: "something stale" },
+    }];
+    printer.name = "New Name";
+
+    await renamePrinterLocations(printer, "Old Name");
+
+    assert.deepEqual(patches, [{ id: 1, payload: { location: "New Name - A0" } }]);
+});

--- a/test/routes.mappings.location.test.js
+++ b/test/routes.mappings.location.test.js
@@ -1,0 +1,170 @@
+import test, { after, before, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import http from "node:http";
+
+import { startTestApp, call } from "./helpers/app.js";
+
+// Assigning and unassigning a spool used to leave the Spoolman location
+// untouched: an assigned 3rd party spool never got one, and an unassigned one
+// kept naming the slot it had left forever. Both go through src/location.js now,
+// and these tests watch what reaches Spoolman.
+
+const patches = [];
+const spools = new Map();
+
+const spoolman = http.createServer((req, res) => {
+    const path = req.url.split("?")[0];
+
+    if (req.method === "GET" && path === "/api/v1/spool") {
+        res.writeHead(200, { "content-type": "application/json" });
+        return res.end(JSON.stringify([...spools.values()]));
+    }
+
+    const id = Number(path.split("/").pop());
+
+    if (req.method === "GET") {
+        const spool = spools.get(id);
+        res.writeHead(spool ? 200 : 404, { "content-type": "application/json" });
+        return res.end(JSON.stringify(spool ?? { detail: "not found" }));
+    }
+
+    let body = "";
+    req.on("data", chunk => { body += chunk; });
+    req.on("end", () => {
+        const payload = JSON.parse(body || "{}");
+        patches.push({ id, payload });
+        const spool = spools.get(id);
+        if (spool) Object.assign(spool, payload);
+        res.writeHead(200, { "content-type": "application/json" });
+        res.end(JSON.stringify(spool ?? { id, ...payload }));
+    });
+});
+
+await new Promise(resolve => spoolman.listen(0, "127.0.0.1", resolve));
+
+// Read at import time by settings.js, so it has to be set before startTestApp
+// pulls the modules in.
+process.env.SPOOLMAN_ENDPOINT = `http://127.0.0.1:${spoolman.address().port}`;
+process.env.SET_LOCATION = "true";
+process.env.LEGACY_MODE = "false";
+
+const SERIAL = "01P00A000000012";
+
+let app;
+let printer;
+
+before(async () => {
+    app = await startTestApp({
+        seedPrinters: [{ id: SERIAL, code: "12345678", ip: "127.0.0.1", name: "Test Printer" }],
+    });
+
+    const { printers } = await import("../src/printers.js");
+    printer = printers.find(p => p.id === SERIAL);
+    printer.currentGcodeState = "IDLE";
+});
+
+after(async () => {
+    await app.close();
+    await new Promise(resolve => spoolman.close(resolve));
+});
+
+/** Puts a spool into the fake Spoolman. */
+function seed(id, location = null) {
+    spools.set(id, { id, location, remaining_weight: 500, filament: { name: `spool ${id}` } });
+    return spools.get(id);
+}
+
+/** Points the cached slot A0 at a spool, the way an AMS update would. */
+function slotHolds(spool) {
+    printer.spoolData = [{
+        amsId: "A0",
+        slotState: "Loaded (3rd party)",
+        slot: { tray_uuid: "N/A", tray_type: "PLA", tray_color: "FF0000FF" },
+        existingSpool: spool ? { ...spool } : null,
+        connectedViaMapping: !!spool,
+        connectedViaTag: false,
+    }];
+}
+
+beforeEach(async () => {
+    patches.length = 0;
+    spools.clear();
+    slotHolds(null);
+    await call(`${app.url}/api/mappings/${SERIAL}/A0`, "DELETE");
+    patches.length = 0;
+});
+
+test("assigning a spool writes the slot as its location", async () => {
+    seed(1);
+
+    const { status } = await call(`${app.url}/api/mappings/${SERIAL}/A0`, "PUT", { spoolId: 1 });
+
+    assert.equal(status, 200);
+    assert.deepEqual(patches, [{ id: 1, payload: { location: "Test Printer - A0" } }]);
+});
+
+test("unassigning a spool clears the location again", async () => {
+    const spool = seed(1, "Test Printer - A0");
+    slotHolds(spool);
+
+    const { status, body } = await call(`${app.url}/api/mappings/${SERIAL}/A0`, "PUT", { spoolId: 1 });
+    assert.equal(status, 200);
+    assert.ok(body.ok);
+    patches.length = 0;
+
+    const removed = await call(`${app.url}/api/mappings/${SERIAL}/A0`, "DELETE");
+
+    assert.equal(removed.status, 200);
+    assert.equal(removed.body.removed, true);
+    assert.deepEqual(patches, [{ id: 1, payload: { location: "" } }]);
+});
+
+test("unassigning leaves a location the user set by hand alone", async () => {
+    const spool = seed(1, "Shelf A");
+    slotHolds(spool);
+    await call(`${app.url}/api/mappings/${SERIAL}/A0`, "PUT", { spoolId: 1 });
+    // The assignment claimed the slot, so put the hand-set location back the way
+    // a user editing it in Spoolman afterwards would.
+    spools.get(1).location = "Shelf A";
+    slotHolds(spools.get(1));
+    patches.length = 0;
+
+    await call(`${app.url}/api/mappings/${SERIAL}/A0`, "DELETE");
+
+    assert.deepEqual(patches, []);
+    assert.equal(spools.get(1).location, "Shelf A");
+});
+
+test("reassigning a slot moves the location from the old spool to the new one", async () => {
+    const previous = seed(1, "Test Printer - A0");
+    seed(2);
+    slotHolds(previous);
+    await call(`${app.url}/api/mappings/${SERIAL}/A0`, "PUT", { spoolId: 1 });
+    patches.length = 0;
+
+    await call(`${app.url}/api/mappings/${SERIAL}/A0`, "PUT", { spoolId: 2 });
+
+    assert.deepEqual(patches, [
+        { id: 1, payload: { location: "" } },
+        { id: 2, payload: { location: "Test Printer - A0" } },
+    ]);
+});
+
+test("unassigning a slot that had nothing assigned writes nothing", async () => {
+    seed(1, "Test Printer - A0");
+
+    const { status, body } = await call(`${app.url}/api/mappings/${SERIAL}/A0`, "DELETE");
+
+    assert.equal(status, 200);
+    assert.equal(body.removed, false);
+    assert.deepEqual(patches, []);
+});
+
+test("a rejected assignment writes no location", async () => {
+    // Spool 7 is not in Spoolman, so the route answers 404 before anything is
+    // stored, and nothing may have been written on the way there either.
+    const { status } = await call(`${app.url}/api/mappings/${SERIAL}/A0`, "PUT", { spoolId: 7 });
+
+    assert.equal(status, 404);
+    assert.deepEqual(patches, []);
+});


### PR DESCRIPTION
## The problem

`SET_LOCATION` was written from two places under two different conditions and cleared from a third that checked nothing, so most of the mechanism did not work.

- **Assign and unassign never touched the location.** `PUT /api/mappings/:printerId/:amsId` stored the mapping and wrote nothing; `DELETE` removed it and cleared nothing. A spool the printer cannot identify therefore never got a location at all, and an unassigned one kept naming the slot it had left for good.
- **Created and merged spools got no location either.** The only write happened when a slot's filament identity changed, which is exactly what it does not do on the update after the spool was created, so it stayed empty until the spool was swapped.
- **Locations the user had set were wiped.** Every spool leaving a slot was patched with an empty location, "Shelf A" included, for no reason other than having been in an AMS once.
- **A spool moved between two slots lost its location.** The slot it entered wrote the new one and the slot it left cleared it again moments later, decided purely by which slot came first in the AMS report.
- **Renaming or removing a printer left `OldName - A0` behind**, which nothing would ever recognise as its own again.

## The change

`src/location.js` is the single write path now.

- A write that would change nothing is skipped. That is what lets the location be checked on *every* AMS update rather than only on an identity change, so a created spool gets one and a location edited in Spoolman by hand is corrected.
- Clearing is guarded by an ownership check: only a location naming this printer is ever removed.
- The changes of an AMS update are collected and applied at the end, claims before releases, so a spool that ends up in any slot is claimed by it and only a spool in none of them is released. Slot order no longer decides the outcome of a move.
- The assign, unassign, rename and delete routes call it directly. The 3rd party create dialog falls back to the slot when its location field is left empty.
- `patchSpoolWeight()` no longer carries the location piggyback in the legacy weight PATCH, which is what let the two conditions drift apart in the first place.

## Verification

- 330 tests pass (302 before, 28 new).
  - `test/location.test.js` covers the ownership rule, the slot move, and the printer rename and removal.
  - `test/routes.mappings.location.test.js` covers the assign and unassign endpoints against a throwaway Spoolman that records what was written.
- Run against `scripts/test-server` in automatic mode with `SET_LOCATION=true`:
  - all 20 occupied slots including the `HT-*` ones get a location, and following updates write nothing at all
  - assign on HT-H writes `Bambu Lab Printer - HT-H`, unassign clears it
  - a hand-set `Shelf A` survives an assign followed by an unassign
  - a rename rewrites every location, a printer removal clears its own and leaves `Shelf A` alone

Not run against physical hardware: the verification above used the mock printer.

## Left as is

Turning `SET_LOCATION` off still does not clear the locations already stored. That would be a destructive bulk write out of a settings toggle, so it stays a separate decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
