### PR TITLE
chore: bump the version to 1.3.0-dev.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 -----------------------------------------------------------------------------------------------
-Unreleased
+Version 1.3.0-dev.6
    - Fixes:
       - The Spoolman location of a spool follows the AMS slot it is really in. SET_LOCATION was written from two places under two different conditions, and cleared from a third that checked nothing, so most of the mechanism did not work:
          - Assigning a spool wrote no location at all and unassigning cleared none, so a spool the printer cannot identify never got a location, and one that was unassigned kept naming the slot it had left for good. Both endpoints write it now, and reassigning a slot moves the location from the old spool to the new one

--- a/OPEN.md
+++ b/OPEN.md
@@ -162,7 +162,7 @@ None of this involved real hardware, so it says nothing about the items above.
 ## Before the next official release
 
 The version deliberately stays on a `-dev` prerelease for now, currently
-`1.3.0-dev.5`.
+`1.3.0-dev.6`.
 
 - [ ] Set the version to `1.3.0` in **both** `package.json` and `src/config.js`.
   The publish workflow compares the tag against `package.json` and aborts on a
@@ -175,7 +175,7 @@ Tag behaviour, after the hardening in `c053561`:
 | Tag | Images | `:latest` | GitHub release |
 |---|---|---|---|
 | `v1.3.0` | `:1.3.0` and `:latest` | moved | release, marked Latest |
-| `v1.3.0-dev`, `v1.3.0-dev.2`, `v1.3.0-dev.3`, `v1.3.0-dev.4`, `v1.3.0-dev.5` | `:<version>` and `:dev` | untouched | pre-release |
+| `v1.3.0-dev`, `v1.3.0-dev.2`, `v1.3.0-dev.3`, `v1.3.0-dev.4`, `v1.3.0-dev.5`, `v1.3.0-dev.6` | `:<version>` and `:dev` | untouched | pre-release |
 | `v1.3.0-rc1` and other suffixes | `:<version>` only | untouched | pre-release |
 
 One `case` decides all four columns, so the image tags and the release cannot

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bambulab-ams-spoolman-filamentstatus",
-  "version": "1.3.0-dev.5",
+  "version": "1.3.0-dev.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bambulab-ams-spoolman-filamentstatus",
-      "version": "1.3.0-dev.5",
+      "version": "1.3.0-dev.6",
       "license": "ISC",
       "dependencies": {
         "adm-zip": "^0.6.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "mqtt": "^5.15.2"
   },
   "name": "bambulab-ams-spoolman-filamentstatus",
-  "version": "1.3.0-dev.5",
+  "version": "1.3.0-dev.6",
   "main": "app.js",
   "type": "module",
   "engines": {

--- a/src/config.js
+++ b/src/config.js
@@ -29,7 +29,7 @@ export const settingsPath = path.join(dataDir, "settings.json");
 // brings the service back on its own or depends on the container policy.
 export const supervised = process.env.SUPERVISED === "1";
 
-export const version = "1.3.0-dev.5";
+export const version = "1.3.0-dev.6";
 export const PORT = 4000;
 export const RECONNECT_INTERVAL = 60000;
 


### PR DESCRIPTION
Bumps the version to `1.3.0-dev.6` ahead of the tag.

`package.json`, `package-lock.json` and `src/config.js` move together: the publish workflow compares the tag against `package.json`, and `src/config.js` is what the Web UI and the diagnostics bundle report, so a bump in only one of them either fails the build or ships an image that lies about its version.

The changelog section that was called `Unreleased` becomes the section for this prerelease, because everything in it ships with the tag and the release body is that section. It carries what #99 changed: the Spoolman location that did not follow the AMS slot the spool was in.

`OPEN.md` lists the new tag next to the other prereleases.

330 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
