### PR TITLE
feat: archive a spool in Spoolman when it runs empty

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -138,7 +138,8 @@ Not punctuation, and therefore allowed:
   config through `src/printers.js`. Never call a Spoolman URL or read
   `printers/` from anywhere else.
 - **When changing the shape of the UI spool object**, update all of its builders
-  in `src/mqtt.js` (`buildEmptySpool`, `buildThirdPartySpool` and the Bambu Lab
+  in `src/mqtt.js` (`buildEmptySpool`, `buildThirdPartySpool`, `buildArchivedSpool`
+  and the Bambu Lab
   branch of `processSlot`), `toClientSpool()` in `src/uispool.js`, and the
   frontend that reads it. A field the projection does not carry never reaches a
   client, and change detection does not see it either: `hasSpoolUiChanged()`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,19 @@
 -----------------------------------------------------------------------------------------------
+Unreleased
+   - New Features:
+      - A spool that runs empty is archived in Spoolman on its own, off by default (issue #65)
+         - "Archive empty spools" in the sync settings turns it on, "Empty threshold" says how many grams left still count as empty, zero by default
+         - The weight it acts on is what Spoolman holds after a booking, never the AMS remain percentage: the percentage is an estimate and reaches 0 while there is still filament on the spool. In legacy mode the two are the same number, because that mode has no other source
+         - Archiving is reversible and nothing is deleted. The location of the archived spool is cleared, so it does not keep naming a slot it is about to leave
+         - An archived spool that is still sitting in its slot is recognised by its tag and left alone. Without that the spool would be gone from Spoolman's spool list, and the automatic mode would create a second record for the same spool on the very next update. The slot says "Loaded (archived)" and offers no action until the spool is taken out or restored
+         - An assignment pointing at a spool that was archived survives. It used to be dropped as "no longer exists in Spoolman", which restoring the spool could not undo
+      - The spool dialog archives and restores a spool by hand, in the row that already showed whether it is archived
+   - Development:
+      - PATCH /api/spoolman/spool/:id takes the archived flag, as a real boolean only, so a string of "false" cannot archive a spool
+      - test/archive.test.js covers the empty decision, including the unknown weight that must never read as used up
+      - The mock Spoolman of scripts/test-server answers like the real one about archived spools: it leaves them out of the spool list unless allow_archived is asked for, and it reports the flag it was given instead of always false. Both were needed to exercise the guard at all
+
+-----------------------------------------------------------------------------------------------
 Version 1.3.0-dev.6
    - Fixes:
       - The Spoolman location of a spool follows the AMS slot it is really in. SET_LOCATION was written from two places under two different conditions, and cleared from a third that checked nothing, so most of the mechanism did not work:

--- a/README.md
+++ b/README.md
@@ -185,6 +185,16 @@ From then on the slot is linked and the consumption of every print is booked ont
 
 Continues up to `D3` for the normal AMS (max. 4 per printer) and up to `HT-H` for all connected AMS HT.
 
+### Archiving empty spools
+
+Off by default. **Settings → Synchronisation → Archive empty spools** archives a spool in Spoolman as soon as it runs empty, so a used up spool leaves the inventory without being deleted. **Empty threshold** (collapsed, advanced) says how many grams left still count as empty; zero by default.
+
+What counts is the weight Spoolman holds after this service wrote to it: the consumption booked at the end of a print, or, in legacy mode, the weight derived from the RFID reading. The AMS remain percentage is never the trigger on its own. It is an estimate and reaches 0 % while there is still filament on the spool, which is why the default threshold is the weight itself rather than the percentage.
+
+Nothing is deleted. An archived spool can be restored in Spoolman, or in the spool dialog of the Web UI, which archives and restores by hand in the same row.
+
+A spool archived while it is still in its slot keeps being recognised by its RFID tag. The slot then reads **Loaded (archived)** and offers no action until the spool is taken out or restored, so the automatic mode cannot create a second record for it.
+
 ## Web UI
 
 Reachable on `http://<host>:4000`. No authentication, see the warning under [Settings](#settings).
@@ -243,7 +253,7 @@ Everything is stored in `printers/settings.json` and applied to the running serv
 | :---- | :---- |
 | **Spoolman connection** | Endpoint, plus host, port, subfolder and public URL in a collapsed section. The line under the field says which URL the service actually talks to |
 | **Tracking** | Operation mode and [legacy mode](#legacy-mode) |
-| **Synchronisation** | AMS update interval, writing the AMS slot as the spool location, never merging a tagged spool |
+| **Synchronisation** | AMS update interval, writing the AMS slot as the spool location, never merging a tagged spool, [archiving empty spools](#archiving-empty-spools) |
 | **Printer connection** | Offline check interval and the retry limit |
 | **Logging** | Debug logging, log file size and how many rotated files are kept, for the server and per printer |
 | **Printers** | Add, edit and remove printers, each with a connection test for MQTT and FTPS |

--- a/public/frontend.js
+++ b/public/frontend.js
@@ -31,6 +31,7 @@ let printerGcodeState = "IDLE";
 // identity line of the row and on the warning triangle in the State column,
 // which names no reason by itself.
 const THIRD_PARTY_HINT = "3rd party spool: no RFID tag, so the printer cannot identify it. Assign a Spoolman spool to track it.";
+const ARCHIVED_HINT = "This spool is archived in Spoolman because it ran empty. Take it out of the slot, or restore it in the spool details.";
 
 // The payload behind every rendered row, by AMS slot id. The detail dialog is
 // opened from a delegated listener, which sees the clicked element rather than
@@ -1550,7 +1551,7 @@ document.addEventListener("DOMContentLoaded", () => {
                     ["Registered", detailDate(spool.registered)],
                     ["First used", detailDate(spool.first_used)],
                     ["Last used", detailDate(spool.last_used)],
-                    ["Archived", spool.archived ? "yes" : "no"],
+                    ["Archived", spool.archived ? "yes" : "no", textField("archived")],
                     ["Lot number", detailText(spool.lot_nr), textField("lotNr")],
                     ["Comment", detailText(spool.comment), textField("comment")],
                     ["Tag", detailExtra(spool.extra?.tag)],
@@ -1595,6 +1596,15 @@ document.addEventListener("DOMContentLoaded", () => {
             value: spool => spool.comment ?? "",
             check: raw => ({ value: raw.trim() }),
         },
+        // Archiving is what the service does by itself for an empty spool, and
+        // this row is both the manual way there and the way back from one that
+        // was archived too early.
+        archived: {
+            type: "select",
+            options: [["false", "no"], ["true", "yes"]],
+            value: spool => (spool.archived ? "true" : "false"),
+            check: raw => ({ value: raw === "true" }),
+        },
     };
 
     // Turns one row into an input in place. The row is rebuilt from the record
@@ -1607,10 +1617,19 @@ document.addEventListener("DOMContentLoaded", () => {
         const before = value.innerHTML;
 
         row.classList.add("sd-row-editing");
+        // A select rather than an input for a field with a fixed set of values:
+        // the same class, so the confirm, cancel and key handling below do not
+        // have to know which of the two they are driving.
+        const control = spec.type === "select"
+            ? `<select class="sd-input">${spec.options
+                .map(([option, label]) => `<option value="${option}"${spec.value(spool) === option ? " selected" : ""}>${label}</option>`)
+                .join("")}</select>`
+            : `<input class="sd-input" type="${spec.type}" ${spec.type === "number" ? 'min="0" step="1"' : 'autocomplete="off"'}
+                    value="${escapeHtml(spec.value(spool))}">`;
+
         value.innerHTML = `
             <span class="sd-editing">
-                <input class="sd-input" type="${spec.type}" ${spec.type === "number" ? 'min="0" step="1"' : 'autocomplete="off"'}
-                    value="${escapeHtml(spec.value(spool))}">
+                ${control}
                 ${spec.unit ? `<span class="gc-muted">${spec.unit}</span>` : ""}
                 <button type="button" class="sd-confirm" title="Save">✓</button>
                 <button type="button" class="sd-cancel" title="Cancel">✕</button>
@@ -1652,7 +1671,7 @@ document.addEventListener("DOMContentLoaded", () => {
         });
 
         input.focus();
-        input.select();
+        if (typeof input.select === "function") input.select();
     }
 
     async function saveSpoolField(field, value, amsSpool, spool) {
@@ -1748,6 +1767,12 @@ document.addEventListener("DOMContentLoaded", () => {
             ? ` · <span class="gc-warn" title="${THIRD_PARTY_HINT}">3rd party</span>`
             : "";
 
+        // The spool is still in the slot, so the row is not an empty one, but
+        // nothing is offered for it until it is taken out or restored.
+        const archived = amsSpool.archived
+            ? ` · <span class="gc-muted" title="${ARCHIVED_HINT}">archived</span>`
+            : "";
+
         const spoolman = amsSpool.existingSpool?.id
             ? `<a class="gc-link" href="${spoolmanBase()}/spool/show/${amsSpool.existingSpool.id}" target="_blank">Spoolman #${amsSpool.existingSpool.id}</a>`
             : `<span class="gc-muted">not linked</span>`;
@@ -1778,7 +1803,7 @@ document.addEventListener("DOMContentLoaded", () => {
         return `
             ${color}${name}${ambiguous}<br>
             <span style="font-size:0.82em">
-                <span class="gc-muted">${amsSpool.amsId} · <code>${isEmpty ? "—" : (slot.tray_info_idx ?? "—")}</code></span>${thirdParty} · ${spoolman}${booking}
+                <span class="gc-muted">${amsSpool.amsId} · <code>${isEmpty ? "—" : (slot.tray_info_idx ?? "—")}</code></span>${thirdParty}${archived} · ${spoolman}${booking}
             </span>`;
     }
 
@@ -2330,6 +2355,7 @@ document.addEventListener("DOMContentLoaded", () => {
     // Set status icon for spool behavior
     function setIcon(status, slotState) {
         if (slotState === "Loaded (Bambu Lab)") return status ? "❗️" : "✅";
+        if (slotState === "Loaded (archived)") return `<span title="${ARCHIVED_HINT}">📦</span>`;
         // Everything else is a warning triangle, so it carries the reason as a
         // tooltip: an untagged 3rd party spool is a normal state, not a fault.
         const title = slotState === "Loaded (3rd party)"

--- a/scripts/test-server/mock-spoolman.js
+++ b/scripts/test-server/mock-spoolman.js
@@ -39,7 +39,7 @@ function expandSpool(spool, filaments) {
         location: spool.location ?? null,
         lot_nr: spool.lot_nr ?? null,
         comment: spool.comment ?? null,
-        archived: false,
+        archived: spool.archived ?? false,
         extra: spool.extra ?? {},
     };
 }
@@ -110,7 +110,15 @@ export function createMockSpoolman(log) {
         res.status(201).json(filament);
     });
 
-    app.get("/api/v1/spool", (_req, res) => res.json(store.spools.map(s => expandSpool(s, store.filaments))));
+    // Spoolman leaves archived spools out of this list unless they are asked
+    // for. That is what archiving is for, and what the service's tag lookup for
+    // an archived spool still sitting in a slot rests on, so the mock has to do
+    // the same or the guard cannot be exercised here.
+    app.get("/api/v1/spool", (req, res) => {
+        const allowArchived = String(req.query.allow_archived) === "true";
+        const spools = store.spools.filter(spool => allowArchived || !spool.archived);
+        res.json(spools.map(s => expandSpool(s, store.filaments)));
+    });
     app.post("/api/v1/spool", (req, res) => {
         const spool = { id: nextSpoolId++, registered: new Date().toISOString(), ...req.body };
         store.spools.push(spool);

--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -152,6 +152,21 @@ build their Spoolman payload from.
   that carries something is emitted, because what an empty one reports has not
   been observed and an entry of empty strings would still reach
   `slotIsOccupied()` carrying its temperature fields.
+- **An archived spool is looked up separately, and only by its tag.** Spoolman
+  leaves archived spools out of `/api/v1/spool`, so a spool this service
+  archived when it ran empty is gone from the list while it is still sitting in
+  its slot, and the automatic mode would create a second record for the same tag
+  on the next update. `getArchivedSpoolmanSpools()` fetches them with
+  `allow_archived=true` and `processSlot()` checks that list before it merges or
+  creates anything. They are never merge candidates, never get a location and
+  never carry a booking: an archived spool is one the user has taken out of the
+  inventory. The fetch only happens while `ARCHIVE_EMPTY_SPOOLS` is on, so the
+  guard costs nothing where nothing archives.
+- **Emptiness comes from Spoolman, not from the AMS.** `spoolIsEmpty()` reads
+  the weight written by the consumption booking, or by the legacy weight patch,
+  which is the only source in that mode. The RFID remain percentage reaches 0
+  while there is still filament on the spool, and archiving on it would take a
+  spool out of the inventory the user is still printing from.
 - **Manual assignment is a G-code mode feature.** `legacyMode()` gates it in
   three places: the 3rd party branch and the Bambu fallback in `processSlot`,
   and `rejectInLegacyMode()` on the mutating routes. A new entry point has to

--- a/src/mqtt.js
+++ b/src/mqtt.js
@@ -5,9 +5,10 @@ import { serverLogFilePath, RECONNECT_INTERVAL } from "./config.js";
 import { settings, spoolmanUrl, legacyMode } from "./settings.js";
 import { originalConsoleLog } from "./logger.js";
 import { state } from "./state.js";
-import { sleep, formatDate, formatInterval, convertAMSandSlot, EXTERNAL_SPOOL_ID, SLOT_OPTIONS, ACTIVE_PRINT_STATES } from "./utils.js";
+import { sleep, formatDate, formatInterval, convertAMSandSlot, spoolIsEmpty, EXTERNAL_SPOOL_ID, SLOT_OPTIONS, ACTIVE_PRINT_STATES } from "./utils.js";
 import {
     getSpoolmanSpools,
+    getArchivedSpoolmanSpools,
     getSpoolmanInternalFilaments,
     getSpoolmanExternalFilaments,
     createSpool,
@@ -15,11 +16,12 @@ import {
     mergeSpool,
     patchSpoolWeight,
     useSpoolWeight,
+    setSpoolArchived,
     logSpoolmanFailure,
 } from "./spoolman.js";
 import { fetchSliceInfo, calcFullConsumption, calcPartialConsumption, resolveSliceSlots, orderedAmsSlots, decodePrintMapping } from "./gcode.js";
 import { getMapping, clearMapping } from "./mappings.js";
-import { createLocationSync } from "./location.js";
+import { createLocationSync, releaseSlotLocation } from "./location.js";
 import {
     processData,
     extractComparableTrayData,
@@ -201,6 +203,42 @@ export function externalSpoolUnits(print) {
 }
 
 /**
+ * Archives a spool that has just run empty, when the setting asks for it.
+ *
+ * Runs on the two places a weight is written: the consumption booking of a
+ * finished print and the legacy mode weight patch. Both already know what the
+ * spool holds afterwards, so nothing is read back and no AMS percentage is
+ * consulted, see `spoolIsEmpty()`.
+ *
+ * The location is cleared first. An archived spool drops out of
+ * `getSpoolmanSpools()`, so no later AMS update sees it in a slot and nothing
+ * would ever release the location it was given while it was in one.
+ *
+ * Failures are logged and swallowed: the weight it archives is already written,
+ * and losing the archive flag must not lose the booking.
+ *
+ * @param {object} printer - the runtime printer, for the log
+ * @param {object|null} spool - the Spoolman record as it is after the write
+ * @returns {Promise<boolean>} whether the spool was archived
+ */
+async function archiveWhenEmpty(printer, spool) {
+    if (!settings.ARCHIVE_EMPTY_SPOOLS) return false;
+    if (!spool?.id || spool.archived) return false;
+    if (!spoolIsEmpty(spool.remaining_weight, settings.EMPTY_SPOOL_THRESHOLD)) return false;
+
+    try {
+        await releaseSlotLocation(printer, spool);
+        await setSpoolArchived(spool.id, true);
+        spool.archived = true;
+        console.log(printer.name, printer.logFilePath, `    Spool-ID ${spool.id} is empty (${Math.round(spool.remaining_weight)}g left), archived in Spoolman`);
+        return true;
+    } catch (err) {
+        console.error(printer.name, printer.logFilePath, `    Failed to archive empty Spool-ID ${spool.id}:`, err.message);
+        return false;
+    }
+}
+
+/**
  * Books the consumed grams in Spoolman for each filament of a finished print.
  *
  * A slot is only booked when we actually know which physical spool sits in it:
@@ -281,8 +319,9 @@ async function bookConsumption(printer, consumption, state) {
 
         const { id: spoolId } = matches[0];
         try {
-            await useSpoolWeight(spoolId, grams, lastUsed);
+            const booked = await useSpoolWeight(spoolId, grams, lastUsed);
             console.log(printer.name, printer.logFilePath, `[Print] Booked ${grams}g for spool ${spoolId} (${matches[0].amsId}, ${idx} ${type} ${color}${matches[0].mapped ? ", manually assigned" : ""})`);
+            await archiveWhenEmpty(printer, booked);
         } catch (err) {
             console.error(printer.name, printer.logFilePath, `[Print] Failed to book consumption for spool ${spoolId}: ${err.message}`);
         }
@@ -368,6 +407,10 @@ async function handleMqttMessage(printer, topic, message) {
 
                         let externalFilaments = await getSpoolmanExternalFilaments();
                         let internalFilaments = await getSpoolmanInternalFilaments();
+                        // Only fetched when the setting can produce archived
+                        // spools in the first place, so an install that does not
+                        // archive pays nothing for the guard.
+                        let archivedSpools = settings.ARCHIVE_EMPTY_SPOOLS ? await getArchivedSpoolmanSpools() : [];
 
                         const spoolsChanged = await haveSpoolDataChanged(spools, state.lastSpoolData);
                         // Legacy mode leaves the holder out. Its weight comes
@@ -401,7 +444,7 @@ async function handleMqttMessage(printer, topic, message) {
                                 }
 
                                 for (const slot of ams.tray) {
-                                    const mutated = await processSlot(printer, ams, slot, spools, externalFilaments, internalFilaments, prevByAmsId, currentTime, locationSync);
+                                    const mutated = await processSlot(printer, ams, slot, spools, archivedSpools, externalFilaments, internalFilaments, prevByAmsId, currentTime, locationSync);
 
                                     // Only refetch when this slot actually created/merged a
                                     // spool or filament in Spoolman. Otherwise the cached
@@ -411,6 +454,7 @@ async function handleMqttMessage(printer, topic, message) {
                                         spools = await getSpoolmanSpools();
                                         externalFilaments = await getSpoolmanExternalFilaments();
                                         internalFilaments = await getSpoolmanInternalFilaments();
+                                        if (settings.ARCHIVE_EMPTY_SPOOLS) archivedSpools = await getArchivedSpoolmanSpools();
                                     }
                                 }
                             }
@@ -548,6 +592,8 @@ export function waitedLongEnoughForRemain(printer, amsId, slot) {
  * @param {object} ams - the AMS unit the slot belongs to
  * @param {object} slot - the normalised slot
  * @param {object[]} spools - Spoolman spools, as fetched for this AMS update
+ * @param {object[]} archivedSpools - the archived spools, empty unless the
+ *     archive setting is on
  * @param {object[]} externalFilaments - the SpoolmanDB catalogue
  * @param {object[]} internalFilaments - filaments in this Spoolman instance
  * @param {object} prevByAmsId - the previous UI spools, keyed by slot label
@@ -557,7 +603,7 @@ export function waitedLongEnoughForRemain(printer, amsId, slot) {
  * @returns {Promise<boolean>} whether Spoolman was mutated, which tells the
  *   caller its cached lists are stale and have to be refetched
  */
-async function processSlot(printer, ams, slot, spools, externalFilaments, internalFilaments, prevByAmsId, currentTime, locationSync) {
+async function processSlot(printer, ams, slot, spools, archivedSpools, externalFilaments, internalFilaments, prevByAmsId, currentTime, locationSync) {
     const amsId = convertAMSandSlot(ams.id, slot.id);
     const validSlot = Object.keys(slot).length > 6;
 
@@ -597,12 +643,14 @@ async function processSlot(printer, ams, slot, spools, externalFilaments, intern
         // Legacy mode has no use for one: it takes the weight from the RFID
         // percentage, which a chipless spool does not report, so the slot stays
         // read-only exactly as it was before assignments existed.
-        const mappedSpool = legacyMode() ? null : resolveMappedSpool(printer, amsId, slot, spools);
+        const mappedSpool = legacyMode() ? null : resolveMappedSpool(printer, amsId, slot, spools, archivedSpools);
         const newUiSpool = buildThirdPartySpool(printer, amsId, slot, mappedSpool);
         // The assignment is the only link a chipless spool has, so it is also
         // the only thing that can give it a location. Nothing did before, which
-        // is why an assigned 3rd party spool never got one at all.
-        locationSync.claim(amsId, mappedSpool);
+        // is why an assigned 3rd party spool never got one at all. An archived
+        // spool is left without one on purpose: archiving cleared it, and no
+        // later update would clear it a second time.
+        if (!mappedSpool?.archived) locationSync.claim(amsId, mappedSpool);
         releasePreviousSpool(locationSync, amsId, prevByAmsId, spools);
         if (hasSpoolUiChanged(newUiSpool, prevByAmsId[newUiSpool.amsId])) {
             broadcastSlotUpdate(printer.id, newUiSpool);
@@ -684,6 +732,11 @@ async function processSlot(printer, ams, slot, spools, externalFilaments, intern
                         await patchSpoolWeight(spool.id, remainingWeight, currentTime);
                         console.log(printer.name, printer.logFilePath, ` [${amsId}] ${slot.tray_sub_brands} ${slot.tray_color} (${currRemain}%) [[ ${slot.tray_uuid} ]]`);
                         console.log(printer.name, printer.logFilePath, `    Updated Spool-ID ${spool.id} => ${spool.filament.name}`);
+                        // The record is the one this pass keeps working with, so
+                        // what was just written has to be on it before anything
+                        // decides whether the spool is empty.
+                        spool.remaining_weight = remainingWeight;
+                        await archiveWhenEmpty(printer, spool);
                     } catch (err) {
                         logSpoolmanFailure({ printerName: printer.name, logFilePath: printer.logFilePath }, "Spool update", err);
                     }
@@ -703,6 +756,23 @@ async function processSlot(printer, ams, slot, spools, externalFilaments, intern
                 break;
             }
         }
+    }
+
+    // An archived spool is gone from `spools`, which is what archiving is for,
+    // and the slot it still sits in would therefore look like a spool Spoolman
+    // has never seen: automatic mode would create a second record for the same
+    // tag on the very next update. The archived list is checked before any of
+    // that, and the slot is left alone.
+    const archivedSpool = found ? null : spoolWithTag(archivedSpools, slot.tray_uuid);
+
+    if (archivedSpool) {
+        const newUiSpool = buildArchivedSpool(printer, amsId, slot, archivedSpool);
+        releasePreviousSpool(locationSync, amsId, prevByAmsId, spools);
+        if (hasSpoolUiChanged(newUiSpool, prevByAmsId[amsId])) {
+            console.log(printer.name, printer.logFilePath, ` [${amsId}] ${slot.tray_sub_brands} ${slot.tray_color} [[ ${slot.tray_uuid} ]] => Spool-ID ${archivedSpool.id} (archived, empty)`);
+        }
+        pushSlotUpdate(printer, newUiSpool, prevByAmsId);
+        return false;
     }
 
     if (!found) {
@@ -813,7 +883,7 @@ async function processSlot(printer, ams, slot, spools, externalFilaments, intern
     // booking which spool to charge, and legacy books nothing: it writes the
     // weight straight onto the tag-connected spool. Offering it there would be
     // a button that changes nothing.
-    const mappedSpool = legacyMode() ? null : resolveMappedSpool(printer, amsId, slot, spools);
+    const mappedSpool = legacyMode() ? null : resolveMappedSpool(printer, amsId, slot, spools, archivedSpools);
     if (mappedSpool) {
         existingSpool = mappedSpool;
         option = SLOT_OPTIONS.UNASSIGN;
@@ -827,7 +897,7 @@ async function processSlot(printer, ams, slot, spools, externalFilaments, intern
     // Only a spool this slot is really connected to may claim it. `existingSpool`
     // can also be a mere merge/creation candidate found by filament match, which
     // is not in the AMS at all and must not be given its location.
-    if (found || mappedSpool) locationSync.claim(amsId, existingSpool);
+    if ((found || mappedSpool) && !existingSpool?.archived) locationSync.claim(amsId, existingSpool);
     releasePreviousSpool(locationSync, amsId, prevByAmsId, spools);
 
     const newUiSpool = {
@@ -843,6 +913,7 @@ async function processSlot(printer, ams, slot, spools, externalFilaments, intern
         // candidates (findExistingSpool).
         connectedViaTag: found,
         connectedViaMapping: !!mappedSpool,
+        archived: !!existingSpool?.archived,
         option,
         enableButton,
         printerName: printer.name,
@@ -901,6 +972,7 @@ function buildThirdPartySpool(printer, amsId, slot, mappedSpool = null) {
         // assignment below, not from an RFID tag.
         connectedViaTag: false,
         connectedViaMapping: !!mappedSpool,
+        archived: !!mappedSpool?.archived,
         correctedWeight,
         // Legacy mode offers nothing here. Its weight comes from the RFID
         // percentage, which this spool does not report, so there is no action
@@ -915,16 +987,77 @@ function buildThirdPartySpool(printer, amsId, slot, mappedSpool = null) {
 }
 
 /**
+ * The spool in `list` whose Spoolman `extra.tag` holds this slot's `tray_uuid`.
+ *
+ * The tag is stored JSON encoded, and a hand edited one that is not decodes to
+ * nothing rather than throwing here, which would otherwise take down the whole
+ * AMS update for one bad record.
+ *
+ * @param {object[]} list - Spoolman spools to search
+ * @param {string} trayUuid - the slot's tag
+ * @returns {object|null}
+ */
+function spoolWithTag(list, trayUuid) {
+    if (!trayUuid) return null;
+
+    return (list || []).find(spool => {
+        if (!spool?.extra?.tag) return false;
+        try {
+            return JSON.parse(spool.extra.tag) === trayUuid;
+        } catch {
+            return false;
+        }
+    }) || null;
+}
+
+/**
+ * Builds the UI entry for a slot still holding a spool that was archived
+ * because it ran empty.
+ *
+ * No action is offered: creating or merging would give the same physical spool
+ * a second record, and assigning another spool to a slot that reports its own
+ * tag is not what the mapping is for. Taking the spool out is the answer, and
+ * restoring it in Spoolman is what brings the slot back to normal.
+ */
+function buildArchivedSpool(printer, amsId, slot, archivedSpool) {
+    return {
+        amsId,
+        slot,
+        mergeableSpool: null,
+        matchingInternalFilament: null,
+        matchingExternalFilament: null,
+        existingSpool: archivedSpool,
+        // Deliberately not a connection: a booking onto an archived spool would
+        // bring it back into the numbers the user just archived away, and the
+        // location sync would hand it the slot it is sitting in again.
+        connectedViaTag: false,
+        connectedViaMapping: false,
+        archived: true,
+        correctedWeight: archivedSpool.remaining_weight ?? null,
+        option: SLOT_OPTIONS.NONE,
+        enableButton: "false",
+        printerName: printer.name,
+        logFilePath: printer.logFilePath,
+        slotState: "Loaded (archived)",
+        error: false,
+    };
+}
+
+/**
  * Looks up the manually assigned Spoolman spool for a slot. Returns null when
  * nothing is assigned, when the assignment went stale (different filament in
  * the slot now, getMapping drops it), or when the assigned spool no longer
  * exists in Spoolman.
  */
-function resolveMappedSpool(printer, amsId, slot, spools) {
+function resolveMappedSpool(printer, amsId, slot, spools, archivedSpools) {
     const mapping = getMapping(printer.id, amsId, slot);
     if (!mapping) return null;
 
-    const spool = (spools || []).find(s => s.id === mapping.spoolId);
+    // The archived list is searched as well, or archiving an assigned spool
+    // would read as "the spool is gone from Spoolman" and throw the assignment
+    // away, which is not something the user asked for and cannot be undone by
+    // restoring the spool.
+    const spool = [...(spools || []), ...(archivedSpools || [])].find(s => s.id === mapping.spoolId);
     if (!spool) {
         console.log(printer.name, printer.logFilePath, `[Mapping] ${amsId}: assigned spool ${mapping.spoolId} no longer exists in Spoolman, dropping assignment`);
         clearMapping(printer.id, amsId);

--- a/src/routes.js
+++ b/src/routes.js
@@ -605,7 +605,7 @@ export function registerRoutes(app, printers) {
         }
     });
 
-    // The three fields the detail dialog may correct by hand. Everything else
+    // The four fields the detail dialog may correct by hand. Everything else
     // about a spool is either derived, owned by this service, or belongs to the
     // filament, so it is edited in Spoolman itself.
     app.patch("/api/spoolman/spool/:id", async (req, res) => {
@@ -641,6 +641,17 @@ export function registerRoutes(app, printers) {
 
         if (req.body?.comment !== undefined) payload.comment = String(req.body.comment).trim();
         if (req.body?.lotNr !== undefined) payload.lot_nr = String(req.body.lotNr).trim();
+
+        // Archiving by hand is the counterpart of the automatic one, and the way
+        // back from it: a spool archived too early is restored from the same
+        // row. Only a real boolean is taken, so a string of "false" cannot
+        // archive a spool.
+        if (req.body?.archived !== undefined) {
+            if (typeof req.body.archived !== "boolean") {
+                return res.status(400).json({ ok: false, error: "The archived flag must be true or false" });
+            }
+            payload.archived = req.body.archived;
+        }
 
         if (!Object.keys(payload).length) {
             return res.status(400).json({ ok: false, error: "Nothing to change" });
@@ -1283,6 +1294,9 @@ function refreshCachedSpool(printers, spool) {
             // Legacy mode owns this field from the AMS reading, and the edit is
             // refused there, so following the spool is right in both modes.
             if (uiSpool.correctedWeight != null) uiSpool.correctedWeight = spool.remaining_weight ?? null;
+            // Archiving or restoring by hand changes what the slot says about
+            // itself, and the next AMS update is up to two minutes away.
+            uiSpool.archived = !!spool.archived;
             broadcastSlotUpdate(printer.id, uiSpool);
         }
     }

--- a/src/settings.js
+++ b/src/settings.js
@@ -98,6 +98,23 @@ export const SETTINGS_SCHEMA = {
         label: "Write AMS slot as location",
         description: "Stores printer name and AMS slot as the location of the spool in Spoolman.",
     },
+    ARCHIVE_EMPTY_SPOOLS: {
+        type: "boolean",
+        default: false,
+        group: "sync",
+        label: "Archive empty spools",
+        description: "Archives a spool in Spoolman as soon as its remaining weight reaches the empty threshold. Archiving is reversible, nothing is deleted.",
+    },
+    EMPTY_SPOOL_THRESHOLD: {
+        type: "integer",
+        default: 0,
+        min: 0,
+        max: 100,
+        group: "sync",
+        advanced: true,
+        label: "Empty threshold",
+        description: "Grams left at which a spool counts as empty. Only used when empty spools are archived.",
+    },
     NEVER_MERGE_IF_TAG: {
         type: "boolean",
         default: false,

--- a/src/spoolman.js
+++ b/src/spoolman.js
@@ -99,6 +99,30 @@ export async function getSpoolmanSpools() {
     }
 }
 
+/**
+ * Fetches the archived spools alone.
+ *
+ * Spoolman leaves archived spools out of `/api/v1/spool`, which is what makes
+ * archiving useful in the first place, and exactly what would make this service
+ * create a second spool for a spool it archived while it still sits in the AMS.
+ * The tag lookup therefore has to see them, and only them: an archived spool is
+ * never a merge candidate and never gets a location.
+ *
+ * Returns an empty list on failure, like `getSpoolmanSpools()`, because it runs
+ * beside it in the same update and a Spoolman outage already pauses processing.
+ */
+export async function getArchivedSpoolmanSpools() {
+    try {
+        const response = await got(`${spoolmanUrl()}/api/v1/spool`, {
+            searchParams: { allow_archived: "true" },
+        });
+        return JSON.parse(response.body).filter(spool => spool.archived);
+    } catch (error) {
+        console.error("Server", serverLogFilePath, "Error fetching archived spools from Spoolman:", error);
+        return [];
+    }
+}
+
 /** Fetches the filaments created in this Spoolman instance, empty on failure. */
 export async function getSpoolmanInternalFilaments() {
     try {
@@ -558,6 +582,20 @@ export async function patchSpoolFields(spoolId, payload) {
     return response.body;
 }
 
+/**
+ * Archives or restores a spool. Rethrows, so a caller can say what failed.
+ *
+ * @param {number} spoolId - Spoolman spool id
+ * @param {boolean} archived - true archives it, false brings it back
+ */
+export async function setSpoolArchived(spoolId, archived) {
+    const response = await got.patch(`${spoolmanUrl()}/api/v1/spool/${spoolId}`, {
+        json: { archived },
+        responseType: "json",
+    });
+    return response.body;
+}
+
 /** Sets a spool's location, or clears it when passed an empty string. */
 export async function patchSpoolLocation(spoolId, location) {
     return got.patch(`${spoolmanUrl()}/api/v1/spool/${spoolId}`, { json: { location } });
@@ -575,6 +613,7 @@ export async function patchSpoolLocation(spoolId, location) {
 export async function useSpoolWeight(spoolId, usedGrams, lastUsed) {
     const result = await got.put(`${spoolmanUrl()}/api/v1/spool/${spoolId}/use`, {
         json: { use_weight: usedGrams },
+        responseType: "json",
     });
 
     // The /use endpoint only accepts use_weight and use_length. A last_used sent
@@ -587,7 +626,10 @@ export async function useSpoolWeight(spoolId, usedGrams, lastUsed) {
         console.error("Server", serverLogFilePath, `Booked consumption for spool ${spoolId}, but could not set last_used:`, error.message);
     }
 
-    return result;
+    // The updated record, which is what the caller needs to see how much the
+    // booking left on the spool. Reading it back with a second request would
+    // race the next booking of a multi filament print.
+    return result.body;
 }
 
 /**

--- a/src/uispool.js
+++ b/src/uispool.js
@@ -51,6 +51,7 @@ function pickSpool(spool) {
     const filament = spool.filament || null;
     return {
         id: spool.id ?? null,
+        archived: spool.archived ?? false,
         remaining_weight: spool.remaining_weight ?? null,
         remaining_percentage: spool.remaining_percentage ?? null,
         initial_weight: spool.initial_weight ?? null,
@@ -121,6 +122,10 @@ export function toClientSpool(uiSpool) {
         matchingExternalFilament,
         connectedViaTag: uiSpool.connectedViaTag ?? false,
         connectedViaMapping: uiSpool.connectedViaMapping ?? false,
+        // The slot holds a spool Spoolman has archived. The dashboard says so
+        // rather than offering an action, and `hasSpoolUiChanged()` compares
+        // this projection, so archiving one reaches the UI as a change.
+        archived: uiSpool.archived ?? false,
         correctedRemain: uiSpool.correctedRemain ?? null,
         correctedWeight: uiSpool.correctedWeight ?? null,
         option: uiSpool.option ?? SLOT_OPTIONS.NONE,

--- a/src/utils.js
+++ b/src/utils.js
@@ -237,3 +237,28 @@ export function catalogueFacet(entries, field, query = {}) {
 
     return [...new Set(values)].sort((a, b) => String(a).localeCompare(String(b)));
 }
+
+/**
+ * Whether a spool counts as empty, and may therefore be archived.
+ *
+ * The weight comes from Spoolman, never from the AMS remain percentage: the
+ * percentage is an estimate the RFID chip reports and it reaches 0 while there
+ * is still filament on the spool, which would archive a spool the user is still
+ * printing from. What Spoolman holds is what this service booked, so it is the
+ * only number an irreversible looking action may rest on.
+ *
+ * A missing weight is never empty. Spoolman leaves `remaining_weight` null for
+ * a spool whose filament has no weight recorded, and "unknown" must not read as
+ * "used up".
+ *
+ * @param {number|null|undefined} remainingWeight - grams Spoolman holds
+ * @param {number} threshold - grams at or below which the spool counts as empty
+ * @returns {boolean}
+ */
+export function spoolIsEmpty(remainingWeight, threshold = 0) {
+    const grams = typeof remainingWeight === "number" ? remainingWeight : Number.NaN;
+    if (!Number.isFinite(grams)) return false;
+
+    const limit = Number(threshold);
+    return grams <= (Number.isFinite(limit) ? limit : 0);
+}

--- a/test/archive.test.js
+++ b/test/archive.test.js
@@ -1,0 +1,42 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { spoolIsEmpty } from "../src/utils.js";
+
+// The one decision behind the automatic archiving of an empty spool. It rests
+// on what Spoolman holds, never on the AMS remain percentage, which is an
+// estimate that reaches 0 while there is still filament on the spool.
+
+test("a spool at or below the threshold is empty", () => {
+    assert.equal(spoolIsEmpty(0), true);
+    assert.equal(spoolIsEmpty(0, 0), true);
+    assert.equal(spoolIsEmpty(5, 10), true);
+    assert.equal(spoolIsEmpty(10, 10), true);
+});
+
+test("a spool above the threshold is not empty", () => {
+    assert.equal(spoolIsEmpty(1), false);
+    assert.equal(spoolIsEmpty(11, 10), false);
+    assert.equal(spoolIsEmpty(950), false);
+});
+
+test("an unknown weight is never empty", () => {
+    // Spoolman leaves remaining_weight null for a spool whose filament carries
+    // no weight, and "unknown" must not archive a spool that may be full.
+    assert.equal(spoolIsEmpty(null), false);
+    assert.equal(spoolIsEmpty(undefined), false);
+    assert.equal(spoolIsEmpty("", 0), false);
+    assert.equal(spoolIsEmpty(NaN), false);
+});
+
+test("a negative weight counts as empty", () => {
+    // Booking more than the spool held leaves Spoolman below zero, which is as
+    // empty as a spool gets.
+    assert.equal(spoolIsEmpty(-3), true);
+});
+
+test("a missing threshold is treated as zero", () => {
+    assert.equal(spoolIsEmpty(0, undefined), true);
+    assert.equal(spoolIsEmpty(0, null), true);
+    assert.equal(spoolIsEmpty(1, null), false);
+});

--- a/test/routes.spooledit.test.js
+++ b/test/routes.spooledit.test.js
@@ -52,12 +52,21 @@ test("a negative remaining weight is refused", async () => {
 });
 
 test("a request that carries no editable field is refused", async () => {
-    // Everything but the three editable fields is dropped, so a payload of only
+    // Everything but the four editable fields is dropped, so a payload of only
     // unknown fields must not reach Spoolman as an empty patch.
-    const { status, body } = await call(`${app.url}/api/spoolman/spool/${SPOOL_ID}`, "PATCH", { archived: true, price: 5 });
+    const { status, body } = await call(`${app.url}/api/spoolman/spool/${SPOOL_ID}`, "PATCH", { price: 5, vendor: "someone" });
 
     assert.equal(status, 400);
     assert.equal(body.error, "Nothing to change");
+});
+
+test("the archived flag has to be a boolean", async () => {
+    // A form that sends "false" as a string would otherwise archive the spool,
+    // because every non empty string is truthy.
+    const { status, body } = await call(`${app.url}/api/spoolman/spool/${SPOOL_ID}`, "PATCH", { archived: "false" });
+
+    assert.equal(status, 400);
+    assert.match(body.error, /archived flag/i);
 });
 
 test("the remaining weight cannot be changed while the spool is in a running print", async () => {


### PR DESCRIPTION
Closes #65.

A used up spool should leave the Spoolman inventory by itself. It archives rather than deletes, so nothing is lost, and it is off by default.

## What it does

* **Settings → Synchronisation → Archive empty spools** turns it on. **Empty threshold** (advanced, 0 g by default, 100 g at most) says how many grams left still count as empty.
* What counts is the weight Spoolman holds after this service wrote to it: the consumption booked at the end of a print, or the legacy mode weight patch, which is the only source in that mode. The AMS remain percentage is never the trigger on its own, because it is an estimate that reaches 0 while there is still filament on the spool. That was the concern raised in the issue.
* A missing `remaining_weight` is never empty, so a filament without a recorded weight cannot archive a full spool.
* The location of the archived spool is cleared, so it does not keep naming a slot it is about to leave.
* The spool dialog archives and restores by hand, in the row that already said whether a spool is archived.

## The guard that had to come with it

Spoolman leaves archived spools out of `/api/v1/spool`. A spool archived while it is still in its slot would therefore look like a tag Spoolman has never seen, and the automatic mode would create a second record for it on the very next update.

`getArchivedSpoolmanSpools()` fetches them with `allow_archived=true` and `processSlot()` checks that list before it merges or creates anything. The slot then reads "Loaded (archived)" and offers no action until the spool is taken out or restored. An assignment pointing at a spool that was archived survives as well, where it used to be dropped as gone from Spoolman.

## Verification

Against the real P2S and a throwaway Spoolman: archiving a loaded spool by hand made the slot read "Loaded (archived)" on the next update, the active spool list dropped from 24 to 23, and nothing was created or merged over the following passes in automatic mode. `PUT /api/v1/spool/{id}/use` was checked against that Spoolman version to return the record the archive decision reads.

Against the mock printer and mock Spoolman: in legacy mode a slot at 0 percent archived its spool once and cleared its location, and after a restart the slot was recognised by its tag with no second spool created.

The automatic trigger was not fired on real hardware, because the lowest loaded spool sits at 26 percent, which is above the highest threshold the setting allows. The write path itself is covered by the mock run above.

`npm test` passes. `test/archive.test.js` covers the empty decision, including the unknown weight that must never read as used up.

The mock Spoolman needed two fixes to be able to show any of this: it served archived spools like any other, and it always reported the flag as false.

🤖 Generated with [Claude Code](https://claude.com/claude-code)