### PR TITLE
fix: a printer that is switched off is asked less often and says so once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,18 @@ Unreleased
          - An archived spool that is still sitting in its slot is recognised by its tag and left alone. Without that the spool would be gone from Spoolman's spool list, and the automatic mode would create a second record for the same spool on the very next update. The slot says "Loaded (archived)" and offers no action until the spool is taken out or restored
          - An assignment pointing at a spool that was archived survives. It used to be dropped as "no longer exists in Spoolman", which restoring the spool could not undo
       - The spool dialog archives and restores a spool by hand, in the row that already showed whether it is archived
+   - Fixes:
+      - A printer that is switched off no longer fills the log, and is no longer probed at the same pace forever (issue #54)
+         - The wait between two reachability checks doubles from the offline check interval up to the new "Offline backoff limit", five minutes by default. A printer that is off for the evening is asked a handful of times instead of hundreds
+         - The log carries one line per backoff step and then goes quiet, where it used to repeat the same unreachable line every interval. It says when the printer answered again
+         - The first failure still waits the plain check interval, so a printer that dropped off for a moment comes back as fast as it did before
+         - Resuming monitoring, reconnecting all printers and saving a printer's address clear the wait, next to the reconnect cooldown they already cleared, so a printer switched back on is picked up at once rather than after the current backoff
+         - Setting the backoff limit to the check interval keeps the constant pace of before
    - Development:
       - PATCH /api/spoolman/spool/:id takes the archived flag, as a real boolean only, so a string of "false" cannot archive a spool
       - test/archive.test.js covers the empty decision, including the unknown weight that must never read as used up
       - The mock Spoolman of scripts/test-server answers like the real one about archived spools: it leaves them out of the spool list unless allow_archived is asked for, and it reports the flag it was given instead of always false. Both were needed to exercise the guard at all
+      - test/monitoring.backoff.test.js covers the growth, the limit, the overflow of a printer that has been away for weeks, and the reset a user action performs
 
 -----------------------------------------------------------------------------------------------
 Version 1.3.0-dev.6

--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ Everything is stored in `printers/settings.json` and applied to the running serv
 | **Spoolman connection** | Endpoint, plus host, port, subfolder and public URL in a collapsed section. The line under the field says which URL the service actually talks to |
 | **Tracking** | Operation mode and [legacy mode](#legacy-mode) |
 | **Synchronisation** | AMS update interval, writing the AMS slot as the spool location, never merging a tagged spool, [archiving empty spools](#archiving-empty-spools) |
-| **Printer connection** | Offline check interval and the retry limit |
+| **Printer connection** | Offline check interval, the backoff limit for a printer that stays offline and the retry limit |
 | **Logging** | Debug logging, log file size and how many rotated files are kept, for the server and per printer |
 | **Printers** | Add, edit and remove printers, each with a connection test for MQTT and FTPS |
 | **Service** | Version, Node, platform, uptime, memory, the tracking mode the process actually runs in, the supervisor state and the Spoolman connection |
@@ -277,6 +277,14 @@ The **Service** card is what a support question usually asks for first, plus the
 
 > [!IMPORTANT]
 > The Web UI has no authentication and is meant for a trusted local network. It can change the printer list and the Spoolman endpoint, so do not expose the port to the internet. The access code of a printer is stored in plain text in `printers/printers.json` and is never sent back to the browser.
+
+### A printer that is switched off
+
+Nothing has to be configured for a printer that is off most of the time. The monitor loop probes it with a plain TCP connect, and the wait between two probes doubles from **Offline check interval** up to **Offline backoff limit** (five minutes by default) for as long as it stays away. The log says so once per step and then goes quiet, instead of repeating the same line every twenty seconds all day, and it says when the printer answered again.
+
+Setting the backoff limit to the check interval keeps the old constant pace.
+
+Anything the user does clears the wait, so a printer switched back on is picked up at once rather than after the current backoff: resuming its monitoring, **Reconnect all printers**, and saving its address. Monitoring can also be switched off per printer, in the Web UI or over the API, which is what the [Home Assistant integration](https://github.com/Rdiger-36/ha-bambulab-ams-spoolman-filamentstatus) drives from a switch: nothing is probed at all while it is off.
 
 ## Diagnostics and privacy
 

--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -85,6 +85,17 @@ build their Spoolman payload from.
   and for implicit TLS that stored host wins over the one passed to `access()`,
   so a shared constant sends every later connection to the printer that used it
   first.
+- **The monitor loop is the only retry driver, and an offline printer is asked
+  on a growing interval.** `monitorPrinters()` keeps ticking at
+  `OFFLINE_CHECK_INTERVAL`, but a printer that failed its last check carries
+  `nextCheckAt` and is skipped until it is due, doubling up to
+  `OFFLINE_MAX_INTERVAL` (`offlineBackoff()` in `utils.js`). A printer that is
+  switched off more often than it is on used to cost one failed connection and
+  one log line every interval, all day. Only a wait that differs from the one
+  already announced is logged, so the log carries one line per backoff step and
+  then goes quiet. Anything the user pressed clears it through
+  `resetOfflineBackoff()`, next to the `setupMqtt()` cooldown it sits beside,
+  because a button is not the monitor loop.
 - **A connection test never disturbs the live connection.** `testMqttConnection`
   opens its own client and force closes it; it must not touch
   `printer.mqttClient`.

--- a/src/mqtt.js
+++ b/src/mqtt.js
@@ -5,7 +5,7 @@ import { serverLogFilePath, RECONNECT_INTERVAL } from "./config.js";
 import { settings, spoolmanUrl, legacyMode } from "./settings.js";
 import { originalConsoleLog } from "./logger.js";
 import { state } from "./state.js";
-import { sleep, formatDate, formatInterval, convertAMSandSlot, spoolIsEmpty, EXTERNAL_SPOOL_ID, SLOT_OPTIONS, ACTIVE_PRINT_STATES } from "./utils.js";
+import { sleep, formatDate, formatInterval, offlineBackoff, convertAMSandSlot, spoolIsEmpty, EXTERNAL_SPOOL_ID, SLOT_OPTIONS, ACTIVE_PRINT_STATES } from "./utils.js";
 import {
     getSpoolmanSpools,
     getArchivedSpoolmanSpools,
@@ -1304,6 +1304,65 @@ function describeMqttError(err) {
 }
 
 /**
+ * Drops the growing wait between the reachability checks of an offline printer.
+ *
+ * The backoff exists to stop the monitor loop asking a printer that is switched
+ * off every twenty seconds. A user who pressed a button is not the monitor loop,
+ * so resuming monitoring, reconnecting or editing a printer clears it, exactly
+ * as they clear the reconnect cooldown of `setupMqtt()`. Without this, a printer
+ * switched back on would wait out a five minute backoff before anything tried.
+ *
+ * @param {object} printer - the runtime printer
+ */
+export function resetOfflineBackoff(printer) {
+    printer.offlineChecks = 0;
+    printer.nextCheckAt = 0;
+    printer.offlineWaitLogged = null;
+}
+
+/**
+ * Records that a printer answered, and says whether it had been away.
+ *
+ * @param {object} printer - the runtime printer
+ * @returns {boolean} whether this is the first answer after failed checks
+ */
+function printerIsBack(printer) {
+    const wasOffline = (printer.offlineChecks || 0) > 0;
+    resetOfflineBackoff(printer);
+    return wasOffline;
+}
+
+/**
+ * Records a failed reachability check and schedules the next one.
+ *
+ * The wait grows with every failure, up to the configured limit, which is what
+ * keeps a printer that is switched off most of the time from being asked every
+ * twenty seconds for hours. It also decides whether this failure is worth a log
+ * line: only a wait that differs from the one already announced is, so a printer
+ * that stays off produces one line per backoff step and then nothing, instead of
+ * the same line forever.
+ *
+ * @param {object} printer - the runtime printer
+ * @param {number} now - the current timestamp
+ */
+function printerStillOffline(printer, now) {
+    const wait = offlineBackoff(printer.offlineChecks || 0, settings.OFFLINE_CHECK_INTERVAL, settings.OFFLINE_MAX_INTERVAL);
+
+    printer.offlineChecks = (printer.offlineChecks || 0) + 1;
+    printer.nextCheckAt = now + wait;
+    printer.mqttStatus = "Disconnected";
+    printer.mqttRunning = false;
+
+    if (printer.offlineWaitLogged === wait) {
+        console.debug(printer.name, printer.logFilePath, `Printer ${printer.id} is still unreachable, next try in ${formatInterval(wait)}`);
+        return;
+    }
+
+    printer.offlineWaitLogged = wait;
+    console.error(printer.name, printer.logFilePath, `Printer ${printer.id} with IP ${printer.ip} is unreachable. Next try in ${formatInterval(wait)}...`);
+}
+
+/**
  * Runs forever, reconnecting printers that are reachable but not connected.
  *
  * This is the single retry driver for MQTT. On every offline check interval each
@@ -1311,6 +1370,11 @@ function describeMqttError(err) {
  * attempted, so an unreachable printer costs one short timeout rather than a
  * hanging MQTT handshake. The whole loop idles while Spoolman is down, since
  * there would be nothing to write AMS data to.
+ *
+ * A printer that does not answer is asked again on a growing interval rather
+ * than on every tick, see `printerStillOffline()`. The loop keeps ticking at the
+ * check interval, because the printers are on their own schedules and a printer
+ * added or re-enabled in the Web UI has to be picked up quickly.
  *
  * @param {object[]} printers - the printer list
  */
@@ -1328,10 +1392,19 @@ export async function monitorPrinters(printers) {
                 continue;
             }
 
+            const now = Date.now();
+            // Not yet due: this printer failed its last check and is waiting out
+            // its backoff. A connected one has no wait, so it is never skipped.
+            if (printer.nextCheckAt && now < printer.nextCheckAt) continue;
+
             try {
                 const isAlive = await checkPrinterAvailability(printer.ip, 8883);
 
                 if (isAlive) {
+                    if (printerIsBack(printer)) {
+                        console.log(printer.name, printer.logFilePath, `Printer ${printer.id} with IP ${printer.ip} is reachable again`);
+                    }
+
                     if (!printer.mqttRunning && !printer.isReconnecting) {
                         if (settings.MAX_RETRIES > 0 && printer.reconnectAttempts >= settings.MAX_RETRIES) {
                             printer.monitoringEnabled = false;
@@ -1344,8 +1417,6 @@ export async function monitorPrinters(printers) {
                         setupMqtt(printer);
                     }
                 } else {
-                    console.error(printer.name, printer.logFilePath, `Printer ${printer.id} with IP ${printer.ip} is unreachable. Next try in ${formatInterval(settings.OFFLINE_CHECK_INTERVAL)}...`);
-
                     if (settings.MAX_RETRIES > 0 && printer.reconnectAttempts >= settings.MAX_RETRIES) {
                         printer.monitoringEnabled = false;
                         printer.mqttRunning = false;
@@ -1353,8 +1424,7 @@ export async function monitorPrinters(printers) {
                         console.log(printer.name, printer.logFilePath, "Printer is unreachable and the retry limit is exceeded, monitoring disabled.");
                         continue;
                     }
-                    printer.mqttStatus = "Disconnected";
-                    printer.mqttRunning = false;
+                    printerStillOffline(printer, now);
                 }
             } catch (error) {
                 console.error(printer.name, printer.logFilePath, `Error monitoring Printer: ${printer.id} - ${error.message}`);

--- a/src/printers.js
+++ b/src/printers.js
@@ -40,6 +40,11 @@ function createRuntimePrinter(entry) {
         lastUpdateTime: new Date(),
         first_run: true,
         monitoringEnabled: true,
+        // The growing wait between two reachability checks of a printer that
+        // does not answer. See monitorPrinters() in mqtt.js.
+        offlineChecks: 0,
+        nextCheckAt: 0,
+        offlineWaitLogged: null,
         // print consumption tracking
         currentGcodeState: "IDLE",
         currentJobName: null,

--- a/src/routes.js
+++ b/src/routes.js
@@ -34,7 +34,7 @@ import {
 } from "./spoolman.js";
 import { fetchSliceInfo, calcFullConsumption, calcPartialConsumption, testFtpsConnection, resolveSliceSlots, orderedAmsSlots } from "./gcode.js";
 import { consumptionCandidate, matchConsumption } from "./ams.js";
-import { setupMqtt, closeMqtt, broadcastSlotUpdate, broadcastSSE, testMqttConnection, ACTIVE_STATES } from "./mqtt.js";
+import { setupMqtt, closeMqtt, broadcastSlotUpdate, broadcastSSE, testMqttConnection, resetOfflineBackoff, ACTIVE_STATES } from "./mqtt.js";
 import { getMappings, setMapping, clearMapping, clearPrinterMappings } from "./mappings.js";
 import {
     claimSlotLocation,
@@ -407,6 +407,7 @@ export function registerRoutes(app, printers) {
             // and the printer only came back on the next monitor pass.
             printer.reconnectAttempts = 0;
             printer.lastReconnectAttempt = 0;
+            resetOfflineBackoff(printer);
             printer.mqttRunning = false;
             printer.mqttStatus = "Reconnecting";
             console.log(printer.name, printer.logFilePath, `Monitoring enabled for ${printer.name} - ${printer.id}, restarting MQTT...`);
@@ -477,6 +478,7 @@ export function registerRoutes(app, printers) {
             // The cooldown in setupMqtt guards against retry storms, not against
             // a deliberate reconnect, so clear it here.
             printer.lastReconnectAttempt = 0;
+            resetOfflineBackoff(printer);
             printer.mqttStatus = "Reconnecting";
             reconnected.push(printer.id);
             setupMqtt(printer);
@@ -1084,6 +1086,7 @@ export function registerRoutes(app, printers) {
             // a deliberate reconnect, so clear it here.
             result.printer.lastReconnectAttempt = 0;
             result.printer.reconnectAttempts = 0;
+            resetOfflineBackoff(result.printer);
             if (result.printer.monitoringEnabled) setupMqtt(result.printer);
         }
 

--- a/src/settings.js
+++ b/src/settings.js
@@ -131,6 +131,16 @@ export const SETTINGS_SCHEMA = {
         label: "Offline check interval",
         description: "Milliseconds between two reachability checks of a disconnected printer.",
     },
+    OFFLINE_MAX_INTERVAL: {
+        type: "integer",
+        default: 300000,
+        min: 20000,
+        max: 3600000,
+        group: "printer",
+        advanced: true,
+        label: "Offline backoff limit",
+        description: "Longest wait between two reachability checks of a printer that stays unreachable. The wait doubles from the offline check interval up to this value. Set it to the check interval to keep the pace constant.",
+    },
     MAX_RETRIES: {
         type: "integer",
         default: 0,

--- a/src/utils.js
+++ b/src/utils.js
@@ -262,3 +262,32 @@ export function spoolIsEmpty(remainingWeight, threshold = 0) {
     const limit = Number(threshold);
     return grams <= (Number.isFinite(limit) ? limit : 0);
 }
+
+/**
+ * How long to wait before the next reachability check of an offline printer.
+ *
+ * A printer that is switched off more often than it is on was checked at the
+ * same pace forever, which is one failed connection and one log line every
+ * interval, all day. The wait doubles from the check interval up to a limit, so
+ * a printer that is off for the evening is asked a handful of times rather than
+ * hundreds, and one that comes back is still found within that limit.
+ *
+ * The first failure waits the base interval, which is what keeps a printer that
+ * dropped off for a moment coming back as fast as it did before.
+ *
+ * @param {number} failures - consecutive failed checks so far, zero on the first
+ * @param {number} base - the configured offline check interval, in ms
+ * @param {number} limit - the longest wait to grow to, in ms
+ * @returns {number} milliseconds to wait before the next check
+ */
+export function offlineBackoff(failures, base, limit) {
+    const start = Number(base) > 0 ? Number(base) : 20000;
+    const max = Number(limit) > 0 ? Math.max(Number(limit), start) : start;
+    const steps = Number.isFinite(Number(failures)) ? Math.max(0, Math.floor(Number(failures))) : 0;
+
+    // 2 ** steps overflows into Infinity for a printer that has been off for
+    // weeks, and Math.min() with it is still the limit, but the intermediate
+    // multiplication is capped rather than relied on.
+    if (steps > 30) return max;
+    return Math.min(start * 2 ** steps, max);
+}

--- a/test/monitoring.backoff.test.js
+++ b/test/monitoring.backoff.test.js
@@ -1,0 +1,53 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { offlineBackoff } from "../src/utils.js";
+import { resetOfflineBackoff } from "../src/mqtt.js";
+
+// A printer that is switched off more often than it is on was probed at the
+// same pace forever, one failed connection and one log line every interval.
+// The wait grows from the check interval up to the configured limit instead.
+
+test("the first failure waits the check interval", () => {
+    // A printer that dropped off for a moment has to come back as fast as it
+    // did before the backoff existed.
+    assert.equal(offlineBackoff(0, 20000, 300000), 20000);
+});
+
+test("the wait doubles with every further failure", () => {
+    assert.equal(offlineBackoff(1, 20000, 300000), 40000);
+    assert.equal(offlineBackoff(2, 20000, 300000), 80000);
+    assert.equal(offlineBackoff(3, 20000, 300000), 160000);
+});
+
+test("the wait stops at the limit", () => {
+    assert.equal(offlineBackoff(4, 20000, 300000), 300000);
+    assert.equal(offlineBackoff(50, 20000, 300000), 300000);
+    // A printer that has been off for weeks must not overflow into Infinity.
+    assert.equal(Number.isFinite(offlineBackoff(2000, 20000, 300000)), true);
+});
+
+test("a limit below the check interval keeps the pace constant", () => {
+    // Which is how the backoff is switched off: the two values are equal.
+    assert.equal(offlineBackoff(0, 60000, 60000), 60000);
+    assert.equal(offlineBackoff(5, 60000, 60000), 60000);
+    assert.equal(offlineBackoff(5, 60000, 10000), 60000);
+});
+
+test("nonsense values fall back to the check interval", () => {
+    assert.equal(offlineBackoff(0, 0, 0), 20000);
+    assert.equal(offlineBackoff(-3, 30000, 300000), 30000);
+    assert.equal(offlineBackoff(Number.NaN, 30000, 300000), 30000);
+});
+
+test("a user action clears the wait a printer had built up", () => {
+    // Resuming monitoring, reconnecting or editing a printer is not the monitor
+    // loop, so it must not wait out a five minute backoff first.
+    const printer = { offlineChecks: 7, nextCheckAt: Date.now() + 300000, offlineWaitLogged: 300000 };
+
+    resetOfflineBackoff(printer);
+
+    assert.equal(printer.offlineChecks, 0);
+    assert.equal(printer.nextCheckAt, 0);
+    assert.equal(printer.offlineWaitLogged, null);
+});


### PR DESCRIPTION
Closes #54.

The issue describes a P1S on a smart plug, off more than it is on. The monitor loop probed it at the same pace forever, so the log carried one failed connection every offline check interval, all day, and raising the interval only made a reachable printer slower to find.

## What changes

* The wait between two reachability checks doubles from **Offline check interval** up to the new **Offline backoff limit** (advanced, five minutes by default), for as long as the printer stays away.
* The first failure still waits the plain interval, so a printer that dropped off for a moment comes back as fast as it did before.
* A line is written only when the wait differs from the one already announced: one line per backoff step, then silence, plus one when the printer answers again. `console.error` has no collapsing prefixes, which is why this line repeated forever where the reconnect lines do not.
* Anything the user pressed clears the wait, next to the reconnect cooldown those paths already cleared: resuming monitoring, **Reconnect all printers**, and saving a printer's address. A printer switched back on is picked up at once rather than after the current backoff.
* Setting the backoff limit to the check interval keeps the constant pace of before.

## Not in here

The wake endpoint for Home Assistant that was floated in the issue thread. Monitoring can already be switched per printer over the API, which is what the integration drives from a switch, and nothing is probed at all while it is off.

## Verification

Against a service pointed at a closed port: the log showed 20 seconds, 40 seconds, 1 minute and then nothing, and opening the port produced "is reachable again" and a reconnect attempt within the capped interval.

Against the real P2S: no unreachable line while it was online, and switching monitoring off and on brought the connection back within one second, so the added reset does not slow the deliberate resume down.

`npm test` passes. `test/monitoring.backoff.test.js` covers the growth, the limit, the overflow of a printer that has been away for weeks, and the reset a user action performs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)