### PR TITLE
chore: bump the version to 1.3.0-dev.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 -----------------------------------------------------------------------------------------------
-Unreleased
+Version 1.3.0-dev.7
    - New Features:
       - A spool that runs empty is archived in Spoolman on its own, off by default (issue #65)
          - "Archive empty spools" in the sync settings turns it on, "Empty threshold" says how many grams left still count as empty, zero by default

--- a/OPEN.md
+++ b/OPEN.md
@@ -162,7 +162,7 @@ None of this involved real hardware, so it says nothing about the items above.
 ## Before the next official release
 
 The version deliberately stays on a `-dev` prerelease for now, currently
-`1.3.0-dev.6`.
+`1.3.0-dev.7`.
 
 - [ ] Set the version to `1.3.0` in **both** `package.json` and `src/config.js`.
   The publish workflow compares the tag against `package.json` and aborts on a
@@ -175,7 +175,7 @@ Tag behaviour, after the hardening in `c053561`:
 | Tag | Images | `:latest` | GitHub release |
 |---|---|---|---|
 | `v1.3.0` | `:1.3.0` and `:latest` | moved | release, marked Latest |
-| `v1.3.0-dev`, `v1.3.0-dev.2`, `v1.3.0-dev.3`, `v1.3.0-dev.4`, `v1.3.0-dev.5`, `v1.3.0-dev.6` | `:<version>` and `:dev` | untouched | pre-release |
+| `v1.3.0-dev`, `v1.3.0-dev.2`, `v1.3.0-dev.3`, `v1.3.0-dev.4`, `v1.3.0-dev.5`, `v1.3.0-dev.6`, `v1.3.0-dev.7` | `:<version>` and `:dev` | untouched | pre-release |
 | `v1.3.0-rc1` and other suffixes | `:<version>` only | untouched | pre-release |
 
 One `case` decides all four columns, so the image tags and the release cannot

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bambulab-ams-spoolman-filamentstatus",
-  "version": "1.3.0-dev.6",
+  "version": "1.3.0-dev.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bambulab-ams-spoolman-filamentstatus",
-      "version": "1.3.0-dev.6",
+      "version": "1.3.0-dev.7",
       "license": "ISC",
       "dependencies": {
         "adm-zip": "^0.6.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "mqtt": "^5.15.2"
   },
   "name": "bambulab-ams-spoolman-filamentstatus",
-  "version": "1.3.0-dev.6",
+  "version": "1.3.0-dev.7",
   "main": "app.js",
   "type": "module",
   "engines": {

--- a/src/config.js
+++ b/src/config.js
@@ -29,7 +29,7 @@ export const settingsPath = path.join(dataDir, "settings.json");
 // brings the service back on its own or depends on the container policy.
 export const supervised = process.env.SUPERVISED === "1";
 
-export const version = "1.3.0-dev.6";
+export const version = "1.3.0-dev.7";
 export const PORT = 4000;
 export const RECONNECT_INTERVAL = 60000;
 


### PR DESCRIPTION
Bumps the version to `1.3.0-dev.7` so the next prerelease tag can be pushed.

- `package.json`, `package-lock.json` and `src/config.js` are bumped together. The publish workflow compares the tag against `package.json`, and `src/config.js` is what the Web UI and the diagnostics bundle report.
- The changelog section that was called `Unreleased` becomes the section for this prerelease — it is the release body. It carries what #101 and #102 changed: the spool that is archived in Spoolman once it runs empty, and the printer that is switched off being probed with a growing backoff instead of at a constant pace forever.
- `OPEN.md` lists `v1.3.0-dev.7` next to the other prereleases and names it as the current version.

Test suite: 342 passing, 0 failing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)