### PR TITLE
chore: bump the version to 1.3.0-dev.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 -----------------------------------------------------------------------------------------------
-Unreleased
+Version 1.3.0-dev.8
    - New Features:
       - Each AMS unit says how it is doing above its slot table: relative humidity, the temperature inside it, and the drying cycle while one is running, with its target temperature and the minutes left
          - What is shown depends on which unit it is, because the units report different things. An AMS 2 Pro and an AMS HT carry a real sensor and a dryer and show all of it. The original AMS and the AMS Lite report only the five step humidity level and show that, since their temperature field is a constant "0.0" rather than a reading. The AMS Lite has no humidity sensor either and was observed always reporting 5, which nothing in the payload separates from an original AMS whose air really is that humid, so the level says where it comes from. The external spool holder reports none of it and gets no header

--- a/OPEN.md
+++ b/OPEN.md
@@ -162,7 +162,7 @@ None of this involved real hardware, so it says nothing about the items above.
 ## Before the next official release
 
 The version deliberately stays on a `-dev` prerelease for now, currently
-`1.3.0-dev.7`.
+`1.3.0-dev.8`.
 
 - [ ] Set the version to `1.3.0` in **both** `package.json` and `src/config.js`.
   The publish workflow compares the tag against `package.json` and aborts on a
@@ -184,7 +184,7 @@ Tag behaviour, after the hardening in `c053561`:
 | Tag | Images | `:latest` | GitHub release |
 |---|---|---|---|
 | `v1.3.0` | `:1.3.0` and `:latest` | moved | release, marked Latest |
-| `v1.3.0-dev`, `v1.3.0-dev.2`, `v1.3.0-dev.3`, `v1.3.0-dev.4`, `v1.3.0-dev.5`, `v1.3.0-dev.6`, `v1.3.0-dev.7` | `:<version>` and `:dev` | untouched | pre-release |
+| `v1.3.0-dev`, `v1.3.0-dev.2`, `v1.3.0-dev.3`, `v1.3.0-dev.4`, `v1.3.0-dev.5`, `v1.3.0-dev.6`, `v1.3.0-dev.7`, `v1.3.0-dev.8` | `:<version>` and `:dev` | untouched | pre-release |
 | `v1.3.0-rc1` and other suffixes | `:<version>` only | untouched | pre-release |
 
 One `case` decides all four columns, so the image tags and the release cannot

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bambulab-ams-spoolman-filamentstatus",
-  "version": "1.3.0-dev.7",
+  "version": "1.3.0-dev.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bambulab-ams-spoolman-filamentstatus",
-      "version": "1.3.0-dev.7",
+      "version": "1.3.0-dev.8",
       "license": "ISC",
       "dependencies": {
         "adm-zip": "^0.6.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "mqtt": "^5.15.2"
   },
   "name": "bambulab-ams-spoolman-filamentstatus",
-  "version": "1.3.0-dev.7",
+  "version": "1.3.0-dev.8",
   "main": "app.js",
   "type": "module",
   "engines": {

--- a/src/config.js
+++ b/src/config.js
@@ -29,7 +29,7 @@ export const settingsPath = path.join(dataDir, "settings.json");
 // brings the service back on its own or depends on the container policy.
 export const supervised = process.env.SUPERVISED === "1";
 
-export const version = "1.3.0-dev.7";
+export const version = "1.3.0-dev.8";
 export const PORT = 4000;
 export const RECONNECT_INTERVAL = 60000;
 


### PR DESCRIPTION
`package.json`, `package-lock.json` and `src/config.js` move together: the publish workflow compares the tag against `package.json` and aborts on a mismatch, and `src/config.js` is what the Web UI and the diagnostics bundle report.

The changelog section called `Unreleased` becomes the section for this prerelease, since everything in it ships with the tag and the release body is that section. It carries what #108 changed: the humidity, temperature and drying cycle above each AMS unit's slot table, the AMS update check that could not fail, and the release notes grouped by label.

This is the first tag whose release body carries that generated overview — `.github/release.yml` is read from the default branch and only reached it with #108.

`OPEN.md` lists the new tag next to the other prereleases.