### PR TITLE
AMS slots are numbered from 1, the way the printer numbers them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ Unreleased
          - A script, a home automation or an integration that called this API without a key stops working and needs one. Create it under "API keys" in the Network access card and send it as "Authorization: Bearer <key>" or "X-API-Key: <key>". The Home Assistant integration is the one to look at first
          - Before this, an installation without a password answered every caller on the network, which is also why the key list could never say who was actually using the API
          - The Web UI is recognised by the Sec-Fetch-Site header the browser sets on every request a page makes, with the Referer as the fallback for browsers too old to send it. That is a fence and not a proof: whoever can open the Web UI can read those headers off their own browser or simply create a key. The proof is the password
+      - AMS slots are numbered the way the printer numbers them: the first slot of the first unit is A1, the last one of a fourth unit is D4. Every slot label moves up by one, in the Web UI, in the logs, in the API and in the Spoolman location of a spool
+         - The assignments in printers/mappings.json are renumbered on the first start, so a spool assigned to the first slot stays with the first slot. The file gains a schemaVersion and holds the assignments under "printers", which is what makes it possible to tell an old A1, the second slot, from a new one, the first
+         - The Spoolman location of a spool follows on the next reading of the AMS, so "P1S - A0" becomes "P1S - A1" without anything to do by hand. Nothing else in Spoolman changes, and a location set by hand is still left alone
+         - A caller of the API sees the new labels in amsId, which is what to look at first for a script or a home automation reading them. The Home Assistant integration is the one to check
+         - Before this the labels counted from 0 while the printer's display, its touchscreen and Bambu Studio all counted from 1, so the second slot of the AMS was A1 on one screen and A2 on the other
    - New Features:
       - The Web UI can ask for a password. "Web UI password" in the Network access card of the settings page turns it on, and until one is set nothing changes: the Web UI stays open to the network, which is how every installation behaved before
          - With a password set, every page and every API call asks for it first. There is one password for the installation, not an account per person, which is what a service on a home network actually needs
@@ -52,6 +57,9 @@ Unreleased
       - isFromOwnUi() in src/security.js is the whole "is this the Web UI" decision as a pure function, covered in test/security.test.js. The test app's call() sends what a browser sends, so a suite that stands in for the Web UI passes and one that stands in for a script deliberately does not
       - The cors dependency is dropped
       - The allow list is read at the point of use rather than captured when the middleware is built, so a name added on the settings page applies to the very next request
+      - printers/mappings.json carries a schemaVersion beside its assignments, read by parseStoredFile() and applied by migrateStored() in src/mappings.js, both covered in test/mappings.test.js. A flat file is version 0 and is renumbered once and written back, since the labels alone cannot say which numbering they were written in
+      - convertAMSandSlot() adds one to the slot id the payload carries and is covered on its own in test/utils.test.js. orderedAmsSlots() counts a unit's slots from 1 with it, which is the path that decides which sliced filament comes out of which slot
+      - The diagnostics bundle masks the serials inside the mapping file's "printers" rather than the keys of the file itself, covered in test/diagnostics.test.js
       - The responsive block of public/styles.css sits at the end of the file, after the desktop rules it has to beat. It stood before them, so a handful of its declarations carried an !important whose only job was to undo the source order; those are gone with the move. The two that are left beat an inline style rather than an order: the column widths the JS column sync writes onto the cells, and the right alignment the weight columns carry in their markup
 
 -----------------------------------------------------------------------------------------------

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -35,7 +35,7 @@ The download needs LAN access to the printer on port 990 (FTPS) with the printer
 Example of a merge in automatic mode:
 
 ```bash
-  - [A0] PETG HF 000000FF (18%) [[ A012456878ABCDEF ]]
+  - [A1] PETG HF 000000FF (18%) [[ A012456878ABCDEF ]]
         - Found mergeable Spool => Spoolman Spool ID: 1, Material: PETG HF, Color: HF Black
           merging Spool...
           Spool successfully merged with Spool-ID 1 => HF Black
@@ -47,10 +47,10 @@ From then on the slot is linked and the consumption of every print is booked ont
 
 | Slot in log | Slot on AMS | Slot in log | Slot on AMS |
 |--------------|----------------------|--------------|---------------------|
-| `A0` – `A3` | first AMS, slot 1 – 4 | `B0` – `B3` | second AMS, slot 1 – 4 |
+| `A1` – `A4` | first AMS, slot 1 – 4 | `B1` – `B4` | second AMS, slot 1 – 4 |
 | `HT-A` | first AMS HT | `HT-B` | second AMS HT |
 
-Continues up to `D3` for the normal AMS (max. 4 per printer) and up to `HT-H` for all connected AMS HT.
+Continues up to `D4` for the normal AMS (max. 4 per printer) and up to `HT-H` for all connected AMS HT.
 
 ## Archiving empty spools
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -19,7 +19,7 @@ Startup and the AMS report:
 [LOG] Bambu Lab P1S - Setting up MQTT connection for Printer: 01PXXXXXXXXXX...
 [LOG] Bambu Lab P1S - MQTT client connected for Printer: 01PXXXXXXXXXX
 [LOG] Bambu Lab P1S - AMS [A] (hum: 5, temp: 0.0ºC)
-[LOG] Bambu Lab P1S -     - [A0] PLA Basic 000000FF [[ XXXXXX00000A ]] => Spool-ID 1 (G-code mode)
+[LOG] Bambu Lab P1S -     - [A1] PLA Basic 000000FF [[ XXXXXX00000A ]] => Spool-ID 1 (G-code mode)
 ```
 
 A slot that is already linked is logged once, when the loaded filament changes. The remain percentage of the AMS is not logged for it, the weight does not come from there.
@@ -30,8 +30,8 @@ A print, from start to booking:
 [LOG] Bambu Lab P1S - [Print] Print running: "bracket.gcode.3mf", fetching slice info via FTPS...
 [LOG] Bambu Lab P1S - [Print] Slice info loaded: 2 filament(s), 260 layers
 [LOG] Bambu Lab P1S - [Print] FINISH, booking filament consumption: {"GFA00|000000":{"tray_info_idx":"GFA00","color":"#000000","type":"PLA","grams":24.7}, ...}
-[LOG] Bambu Lab P1S - [Print] Booked 24.7g for spool 1 (A0, GFA00 PLA #000000)
-[LOG] Bambu Lab P1S - [Print] Booked 3.1g for spool 7 (A2, GFA01 PLA #FFFFFF, manually assigned)
+[LOG] Bambu Lab P1S - [Print] Booked 24.7g for spool 1 (A1, GFA00 PLA #000000)
+[LOG] Bambu Lab P1S - [Print] Booked 3.1g for spool 7 (A3, GFA01 PLA #FFFFFF, manually assigned)
 ```
 
 A slot that is neither tag-linked nor manually assigned is named and skipped, so the log says which spool is missing its link:

--- a/public/frontend.js
+++ b/public/frontend.js
@@ -34,7 +34,7 @@ const THIRD_PARTY_HINT = "3rd party spool: no RFID tag, so the printer cannot id
 const ARCHIVED_HINT = "This spool is archived in Spoolman because it ran empty. Take it out of the slot, or restore it in the spool details.";
 
 // Humidity, temperature and drying state per AMS unit, keyed by the unit part
-// of a slot label ("A" for A0 to A3, "HT-A" for a single slot unit). Mirrored
+// of a slot label ("A" for A1 to A4, "HT-A" for a single slot unit). Mirrored
 // from /api/status and kept fresh by the ams_env SSE event, which arrives at
 // most every 30 seconds because the readings never sit still.
 let amsEnvByUnit = {};

--- a/scripts/test-server/scenario.js
+++ b/scripts/test-server/scenario.js
@@ -109,7 +109,7 @@ const TPU = { type: "TPU", material: "TPU 90A", idx: "GFU02", name: "U02-T0", no
  * The AMS units as `print.ams.ams` carries them.
  *
  * The ids are the full range `convertAMSandSlot()` knows: 0 to 3 for the
- * regular units, giving A0 to D3, and 128 to 135 for the single slot AMS HT
+ * regular units, giving A1 to D4, and 128 to 135 for the single slot AMS HT
  * units, giving HT-A to HT-H.
  */
 export const AMS_UNITS = [
@@ -322,7 +322,7 @@ export const SEED_FILAMENTS = [
 /**
  * The spools the mock Spoolman starts with.
  *
- * The two tagged ones are what makes A0 and C0 report as connected. The two
+ * The two tagged ones are what makes A1 and C1 report as connected. The two
  * untagged ones are merge candidates and fill the assignment picker, where a
  * multi colour spool used to be the entry with no colour next to it.
  */

--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -32,7 +32,7 @@ and `../starting.js`) or the Express app wiring itself (`../backend.js`).
 | `security.js` | The request guard: which `Host` a request may be addressed to, which `Origin` may change something, and whether a request came from the Web UI itself (`isFromOwnUi()`, which `auth.js` uses). Pure decisions plus the middleware `backend.js` puts in front of everything. The allow list is `settings.ALLOWED_HOSTS`, read per request. |
 | `uispool.js` | `toClientSpool()`, the one projection from a runtime UI spool to what a client sees. Used by `/api/spools`, `/api/print`, the SSE slot update and `hasSpoolUiChanged()`. |
 | `state.js` | Shared mutable process state (Spoolman status, vendor id, SSE clients, last spool snapshot). |
-| `utils.js` | Date/interval formatting, `sleep`, AMS id to slot label (`A0`, `HT-A`), and `slotColors()`, the colour set of a slot. It lives here because both `ams.js` and `uispool.js` need it and `ams.js` already imports `uispool.js`. |
+| `utils.js` | Date/interval formatting, `sleep`, AMS id to slot label (`A1`, `HT-A`), and `slotColors()`, the colour set of a slot. It lives here because both `ams.js` and `uispool.js` need it and `ams.js` already imports `uispool.js`. |
 
 ## The two tracking modes
 
@@ -200,7 +200,7 @@ build their Spoolman payload from.
 - **The sliced file names the slot, and that beats every colour comparison.**
   The position of a filament in Bambu Studio's list is the AMS slot it was
   sliced for, verified against a real print on a P2S with two AMS units where
-  the ids 5, 7 and 8 were B0, B2 and B3. It is the only thing that separates two
+  the ids 5, 7 and 8 were B1, B3 and B4. It is the only thing that separates two
   spools identical in profile and colour, so `calcFullConsumption()` keys by
   that position: two filaments never merge, where a colour key added them
   together before anything looked at the AMS and the sum could not be split
@@ -208,7 +208,7 @@ build their Spoolman payload from.
 - **The printer says which slot a print runs each filament from, and that beats
   working it out.** `print.mapping` carries one entry per filament of the
   slicer's project, the unit in the high byte and the slot in the low one:
-  `0x0100` is B0, `0xFF00` the external holder, `0xFFFF` a filament the plate
+  `0x0100` is B1, `0xFF00` the external holder, `0xFFFF` a filament the plate
   does not use. `decodePrintMapping()` turns it into the same shape
   `orderedAmsSlots()` produces, so `resolveSliceSlots()` takes either without
   knowing which. It is captured at the transition to RUNNING and kept on the

--- a/src/diagnostics.js
+++ b/src/diagnostics.js
@@ -7,6 +7,7 @@ import { version, dataDir, logsDir, serverLogFilePath, mappingsPath, supervised 
 import { deprecatedConfig } from "./deprecation.js";
 import { logFileSet } from "./logger.js";
 import { printers } from "./printers.js";
+import { parseStoredFile } from "./mappings.js";
 import { apiKeyCount } from "./apikeys.js";
 import { getSettingsView, legacyMode } from "./settings.js";
 import { state } from "./state.js";
@@ -144,11 +145,14 @@ export async function buildDiagnosticsBundle({ anonymize = true } = {}) {
 
     const mappings = readJsonOrNull(mappingsPath);
     if (mappings) {
+        // Read through the mapping module's own parser, so the wrapper the file
+        // carries stays intact and only the assignments inside it are masked
+        const { printers: assignments, schemaVersion } = parseStoredFile(mappings);
         // Keyed by serial number, so the keys need masking as well
         const exported = anonymize
-            ? Object.fromEntries(Object.entries(mappings).map(([serial, value]) => [maskSerial(serial), value]))
-            : mappings;
-        zip.addFile("mappings.json", Buffer.from(JSON.stringify(exported, null, 4)));
+            ? Object.fromEntries(Object.entries(assignments).map(([serial, value]) => [maskSerial(serial), value]))
+            : assignments;
+        zip.addFile("mappings.json", Buffer.from(JSON.stringify({ schemaVersion, printers: exported }, null, 4)));
     }
 
     await addLogFiles(zip, "logs/server", serverLogFilePath, mask);

--- a/src/gcode.js
+++ b/src/gcode.js
@@ -131,13 +131,13 @@ export function consumptionKey(trayInfoIdx, color, colors = null) {
  *
  * Bambu Studio's filament list is the printer's slot list, so the position in
  * it is the slot: the fifth entry is the fifth slot. Verified against a print
- * sliced for a P2S with two AMS units, where the ids 5, 7 and 8 were B0, B2
- * and B3.
+ * sliced for a P2S with two AMS units, where the ids 5, 7 and 8 were B1, B3
+ * and B4.
  *
  * The position is resolved against the slots the printer actually reports,
  * never against a computed geometry. A second file settled that: with two AMS
  * units and a spool on the external holder the list holds nine entries, and
- * arithmetic on "four slots per unit" turns the ninth into "C0", a unit that
+ * arithmetic on "four slots per unit" turns the ninth into "C1", a unit that
  * printer does not have. The list length is no help either, it is the project's
  * filament count and not the printer's: the same P2S produced files with six,
  * eight and nine entries.
@@ -188,8 +188,10 @@ const MAPPING_UNUSED = 0xFFFF;
  *
  * One entry per filament of the slicer's project, in the same order, so the
  * result drops straight into `resolveSliceSlots()`. Each is the unit in the
- * high byte and the slot in the low one: 0x0100 is B0, 0x0002 is A2, 0xFF00 is
+ * high byte and the slot in the low one: 0x0100 is B1, 0x0002 is A3, 0xFF00 is
  * the external holder, and 0xFFFF means the plate does not use that filament.
+ * Both bytes count from 0, while the labels count a unit's slots from 1, which
+ * is what `convertAMSandSlot()` is doing to the low byte.
  *
  * Read off a P2S across two prints, where all seven entries matched the slots
  * the print was really running from, including the holder and the unused
@@ -249,8 +251,8 @@ export function orderedAmsSlots(amsIds) {
     const ids = (amsIds || []).filter(id => typeof id === "string");
     const units = ["A", "B", "C", "D"];
 
-    const attached = units.filter(unit => ids.some(id => id[0] === unit && /^[0-3]$/.test(id[1])));
-    const fourSlotUnits = attached.flatMap(unit => [0, 1, 2, 3].map(slot => `${unit}${slot}`));
+    const attached = units.filter(unit => ids.some(id => id[0] === unit && /^[1-4]$/.test(id[1])));
+    const fourSlotUnits = attached.flatMap(unit => [1, 2, 3, 4].map(slot => `${unit}${slot}`));
 
     const highTemperature = ids.filter(id => /^HT-[A-H]$/.test(id)).sort();
     const external = ids.includes(EXTERNAL_SLOT) ? [EXTERNAL_SLOT] : [];

--- a/src/location.js
+++ b/src/location.js
@@ -10,7 +10,7 @@ import { patchSpoolLocation, getSpoolmanSpool } from "./spoolman.js";
  * `public/frontend.js`.
  *
  * @param {string} printerName - the printer's display name
- * @param {string} amsId - slot label, e.g. "A0", "HT-A" or "External"
+ * @param {string} amsId - slot label, e.g. "A1", "HT-A" or "External"
  * @returns {string} the location to store in Spoolman
  */
 export function slotLocation(printerName, amsId) {
@@ -25,8 +25,8 @@ export function slotLocation(printerName, amsId) {
  * reason other than the spool having been in an AMS once. A location is only
  * ours to clear when it names this printer, so anything else survives.
  *
- * The slot part is not checked: a spool moved from A0 to A1 carries
- * `Printer - A0` until the new slot is written, and that is still ours.
+ * The slot part is not checked: a spool moved from A1 to A2 carries
+ * `Printer - A1` until the new slot is written, and that is still ours.
  *
  * @param {string|null|undefined} location - the spool's current location
  * @param {string} printerName - the printer whose slot released the spool
@@ -100,8 +100,8 @@ export async function releaseSlotLocation(printer, spool) {
  * Collects the location changes of one AMS update and applies them at the end.
  *
  * Writing them as the slots are walked was wrong for the case a spool changes
- * slot: moving one from A1 to A0 wrote `Printer - A0` while A0 was processed
- * and then, one slot later, cleared it again, because A1 saw the spool it used
+ * slot: moving one from A2 to A1 wrote `Printer - A1` while A1 was processed
+ * and then, one slot later, cleared it again, because A2 saw the spool it used
  * to hold gone and had no way to know it had just reappeared elsewhere. Slot
  * order decided whether a move kept its location or lost it.
  *

--- a/src/mappings.js
+++ b/src/mappings.js
@@ -13,13 +13,24 @@ import { slotColors } from "./utils.js";
  * identical in tray_info_idx and color.
  *
  * Shape:
- *   { "<printerId>": { "A0": { spoolId, fingerprint, updatedAt } } }
+ *   { schemaVersion, printers: { "<printerId>": { "A1": { spoolId, fingerprint, updatedAt } } } }
  *
  * The fingerprint identifies the physical spool as far as the AMS can describe
  * it. When it stops matching, a different spool was put into that slot and the
  * assignment is dropped rather than silently booking onto the wrong spool.
  */
 let mappings = null;
+
+/**
+ * The version of the file this module writes.
+ *
+ * 1 is the first version with a wrapper around the printers, and the first
+ * whose slot labels count a unit's slots from 1. Version 0 is the flat file
+ * every installation before it has on disk, whose keys are the same assignments
+ * under the labels `A0` to `D3`. Bump this whenever the meaning of what is
+ * stored changes and handle the old value in `migrateStored()`.
+ */
+export const MAPPINGS_SCHEMA_VERSION = 1;
 
 /**
  * Describes a slot's filament as precisely as the AMS allows for a chipless
@@ -93,22 +104,87 @@ function fingerprintMatches(stored, slot) {
 }
 
 /**
+ * Reads the two shapes the file can have.
+ *
+ * The first version stored the printers flat at the top level. Everything since
+ * wraps them, so the file can carry the version its slot labels were written
+ * with. A flat file is therefore version 0 rather than the current one: that is
+ * the whole signal the renumbering below has to go on, since a file holding
+ * `A1` alone says nothing about whether that is the second slot of the old
+ * labels or the first of the new ones.
+ *
+ * @param {object} parsed - the parsed file contents
+ * @returns {{printers: object, schemaVersion: number}}
+ */
+export function parseStoredFile(parsed) {
+    if (parsed && typeof parsed.printers === "object" && parsed.printers !== null && !Array.isArray(parsed.printers)) {
+        return {
+            printers: parsed.printers,
+            schemaVersion: Number.isInteger(parsed.schemaVersion) ? parsed.schemaVersion : MAPPINGS_SCHEMA_VERSION,
+        };
+    }
+
+    return { printers: parsed ?? {}, schemaVersion: 0 };
+}
+
+/**
+ * Brings a stored set of assignments up to the current schema version.
+ *
+ * Version 0 numbered a unit's slots from 0, so its keys are `A0` to `D3` where
+ * the same physical slots are now `A1` to `D4`. Every key is shifted by one, or
+ * the assignments of an existing install would sit one slot off: the spool the
+ * user assigned to the first slot would answer for the second and the last one
+ * would answer for nothing at all.
+ *
+ * Only the four slot units carry a number. `HT-A` to `HT-H` and `External` name
+ * a unit that has a single slot and are passed through, as is anything else the
+ * file happens to hold, because dropping a key nobody recognises loses an
+ * assignment over a label this version does not know yet.
+ *
+ * @param {object} printers - the stored assignments, keyed by printer id
+ * @param {number} schemaVersion - the version they were written with
+ * @returns {object} the assignments in the current shape
+ */
+export function migrateStored(printers, schemaVersion) {
+    if (schemaVersion >= MAPPINGS_SCHEMA_VERSION) return printers;
+
+    const renumber = slots => Object.fromEntries(
+        Object.entries(slots || {}).map(([amsId, entry]) => {
+            const match = /^([A-D])([0-3])$/.exec(amsId);
+            return [match ? `${match[1]}${Number(match[2]) + 1}` : amsId, entry];
+        }),
+    );
+
+    return Object.fromEntries(Object.entries(printers).map(([printerId, slots]) => [printerId, renumber(slots)]));
+}
+
+/**
  * Loads the mapping file once and caches it for the process lifetime.
  *
  * A missing file is the normal first run case and yields an empty map. So does
  * a corrupt one, because refusing to start over an unreadable convenience cache
  * would be worse than losing the assignments in it.
  *
- * @returns {object} the whole mapping structure, keyed by printer id
+ * A file that had to be migrated is written back immediately, so that the
+ * version on disk states what its labels mean rather than being renumbered
+ * again on every start.
+ *
+ * @returns {object} the assignments of every printer, keyed by printer id
  */
 function load() {
     if (mappings) return mappings;
 
+    let migrated = false;
+
     try {
-        mappings = JSON.parse(fs.readFileSync(mappingsPath, "utf-8"));
-        if (typeof mappings !== "object" || mappings === null || Array.isArray(mappings)) {
+        const parsed = JSON.parse(fs.readFileSync(mappingsPath, "utf-8"));
+        if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
             throw new Error("mappings.json must contain an object");
         }
+
+        const file = parseStoredFile(parsed);
+        migrated = file.schemaVersion < MAPPINGS_SCHEMA_VERSION;
+        mappings = migrateStored(file.printers, file.schemaVersion);
         console.debug("Server", serverLogFilePath, "Spool mappings loaded:", JSON.stringify(mappings));
     } catch (err) {
         // Missing file is the normal first-run case; anything else is worth a log
@@ -116,6 +192,11 @@ function load() {
             console.error("Server", serverLogFilePath, "Could not read mappings.json, starting empty:", err.message);
         }
         mappings = {};
+    }
+
+    if (migrated) {
+        console.log("Server", serverLogFilePath, `[Mapping] Slot labels renumbered to schema ${MAPPINGS_SCHEMA_VERSION}, a unit's slots now count from 1 (A0 became A1)`);
+        persist();
     }
 
     return mappings;
@@ -126,8 +207,9 @@ function persist() {
     // Write to a temp file and rename, so a crash mid-write cannot leave a
     // truncated mappings.json behind.
     const tmp = `${mappingsPath}.tmp`;
+    const payload = { schemaVersion: MAPPINGS_SCHEMA_VERSION, printers: mappings };
     try {
-        fs.outputFileSync(tmp, JSON.stringify(mappings, null, 2));
+        fs.outputFileSync(tmp, JSON.stringify(payload, null, 2));
         fs.renameSync(tmp, mappingsPath);
     } catch (err) {
         console.error("Server", serverLogFilePath, "Failed to save mappings.json:", err.message);
@@ -176,7 +258,7 @@ export function getMapping(printerId, amsId, slot = null) {
  * stores an assignment that is never invalidated by a filament change.
  *
  * @param {string} printerId - printer serial
- * @param {string} amsId - slot label, e.g. "A0"
+ * @param {string} amsId - slot label, e.g. "A1"
  * @param {number|string} spoolId - Spoolman spool id
  * @param {object|null} slot - the AMS slot the assignment was made from
  * @returns {object} the stored entry

--- a/src/utils.js
+++ b/src/utils.js
@@ -47,15 +47,21 @@ export function formatInterval(ms) {
  * Turns the numeric AMS unit and slot ids from MQTT into the slot label used
  * throughout the UI, the logs and the mapping file.
  *
- * Regular AMS units are 0 to 3 and carry four slots each, giving `A0` to `D3`.
+ * Regular AMS units are 0 to 3 and carry four slots each, giving `A1` to `D4`.
  * The single slot AMS HT units are 128 to 135 and have no slot number of their
  * own, giving `HT-A` to `HT-H`. 255 is the external spool holder, which the
  * printer reports outside the AMS block altogether and which has no slot number
  * either, giving `External`. Anything outside those ranges yields `Z`, which
  * marks a unit this service does not know how to address.
  *
+ * The slot number is the printer's, not the payload's: MQTT counts a unit's
+ * slots from 0, while the printer's own display, its touchscreen and Bambu
+ * Studio all count them from 1. The label is read next to that hardware, so it
+ * says what the hardware says.
+ *
  * The label is not only shown: it is the key an assignment is stored under in
  * `mappings.json`, so changing one orphans the assignments already on disk.
+ * `migrateStored()` in `mappings.js` renumbers the keys written before this.
  *
  * @param {number|string} amsID  - AMS unit id from `print.ams.ams[].id`
  * @param {number|string|null} slotID - slot id within the unit, null for none
@@ -65,9 +71,12 @@ export function convertAMSandSlot(amsID, slotID) {
     amsID = Number(amsID);
     const letters = ["A", "B", "C", "D", "E", "F", "G", "H"];
 
-    if (slotID === null) slotID = "";
+    // Anything that is not a slot number leaves the label without one, which is
+    // how a whole unit is named: `convertAMSandSlot(0, null)` is "A".
+    const number = Number(slotID);
+    const slot = slotID === null || slotID === "" || !Number.isFinite(number) ? "" : number + 1;
 
-    if (amsID >= 0 && amsID <= 3) return letters[amsID] + slotID;
+    if (amsID >= 0 && amsID <= 3) return letters[amsID] + slot;
     if (amsID >= 128 && amsID <= 135) return `HT-${letters[amsID - 128]}`;
     if (amsID === EXTERNAL_SPOOL_ID) return EXTERNAL_SLOT;
     return "Z";

--- a/test/ams.slotmatch.test.js
+++ b/test/ams.slotmatch.test.js
@@ -9,8 +9,8 @@ import { slotConfirmsSlice, matchConsumption, consumptionCandidate } from "../sr
 // written before that, so the slot is confirmed against what the AMS reports
 // for it now rather than taken on trust.
 
-const candidate = (idx, colors) => ({ id: 1, amsId: "B0", mapped: false, idx, colors });
-const entry = (idx, color, colors = null) => ({ tray_info_idx: idx, color, colors, amsId: "B0" });
+const candidate = (idx, colors) => ({ id: 1, amsId: "B1", mapped: false, idx, colors });
+const entry = (idx, color, colors = null) => ({ tray_info_idx: idx, color, colors, amsId: "B1" });
 
 test("a slot holding what the slice expected confirms it", () => {
     assert.equal(
@@ -68,11 +68,11 @@ test("a slot with no profile at all refuses", () => {
 /* ---- A reported slot is trusted, an estimated one is confirmed ---- */
 
 // Read off a live print. The slice held Army Green on the external holder, and
-// the print was started with the orange spool in A1 selected for that filament
-// by mistake. print.mapping said A1, which was right: A1 is what the printer
+// the print was started with the orange spool in A2 selected for that filament
+// by mistake. print.mapping said A2, which was right: A2 is what the printer
 // would have consumed.
-const armyGreenSlice = { index: 3, amsId: "A1", tray_info_idx: "GFL99", color: "#5E6345", colors: null };
-const orangeInA1 = { id: 9, amsId: "A1", mapped: true, idx: "GFL99", colors: ["f98c36"] };
+const armyGreenSlice = { index: 3, amsId: "A2", tray_info_idx: "GFL99", color: "#5E6345", colors: null };
+const orangeInA1 = { id: 9, amsId: "A2", mapped: true, idx: "GFL99", colors: ["f98c36"] };
 
 test("a slot the printer reported is not checked against the sliced colour", () => {
     // Confirming it rejected the one answer that was right. A filament
@@ -97,7 +97,7 @@ test("an estimated slot still has to hold what the slice expects", () => {
     const stage = (candidate, info) =>
         !!info.amsId && candidate.amsId === info.amsId && (info.amsIdFromPrinter || slotConfirmsSlice(candidate, info));
 
-    const matchingSlot = { id: 1, amsId: "A1", mapped: false, idx: "GFL99", colors: ["5e6345"] };
+    const matchingSlot = { id: 1, amsId: "A2", mapped: false, idx: "GFL99", colors: ["5e6345"] };
     assert.equal(stage(matchingSlot, { ...armyGreenSlice, amsIdFromPrinter: false }), true);
 });
 
@@ -124,18 +124,18 @@ const filament = (index, { idx = null, color = null, colors = null, type = "PLA"
 const matchedSlot = (entries, candidates, entry) => matchConsumption(entries, candidates).get(entry)?.[0]?.amsId ?? null;
 
 test("the slot the printer named wins, whatever colour sits in it", () => {
-    const sliced = filament(0, { idx: "GFL99", color: "#5E6345", amsId: "A1", fromPrinter: true });
-    const slots = [spool("A0", { id: 1, idx: "GFL99", color: "5E6345", tag: true }), spool("A1", { id: 2, idx: "GFL99", color: "F98C36", tag: true })];
+    const sliced = filament(0, { idx: "GFL99", color: "#5E6345", amsId: "A2", fromPrinter: true });
+    const slots = [spool("A1", { id: 1, idx: "GFL99", color: "5E6345", tag: true }), spool("A2", { id: 2, idx: "GFL99", color: "F98C36", tag: true })];
 
-    assert.equal(matchedSlot([sliced], slots, sliced), "A1");
+    assert.equal(matchedSlot([sliced], slots, sliced), "A2");
 });
 
 test("an estimated slot has to hold what the slice expects, or the stages below decide", () => {
-    const sliced = filament(0, { idx: "GFA00", color: "#5E6345", amsId: "A1" });
-    const slots = [spool("A0", { id: 1, idx: "GFA00", color: "5E6345", tag: true }), spool("A1", { id: 2, idx: "GFA00", color: "F98C36", tag: true })];
+    const sliced = filament(0, { idx: "GFA00", color: "#5E6345", amsId: "A2" });
+    const slots = [spool("A1", { id: 1, idx: "GFA00", color: "5E6345", tag: true }), spool("A2", { id: 2, idx: "GFA00", color: "F98C36", tag: true })];
 
-    // A1 is what the list order estimated, A0 is what actually holds the colour.
-    assert.equal(matchedSlot([sliced], slots, sliced), "A0");
+    // A2 is what the list order estimated, A1 is what actually holds the colour.
+    assert.equal(matchedSlot([sliced], slots, sliced), "A1");
 });
 
 test("a slot the printer named for one filament is not claimed by another", () => {
@@ -143,13 +143,13 @@ test("a slot the printer named for one filament is not claimed by another", () =
     // slots showed every figure twice, on the slot being consumed and on the
     // slot merely holding the colour the file was sliced with. The second one
     // reaches the colour stage and matches, unless the claim is respected.
-    const remapped = filament(0, { idx: "GFA00", color: "#FFFFFF", amsId: "A1", fromPrinter: true });
+    const remapped = filament(0, { idx: "GFA00", color: "#FFFFFF", amsId: "A2", fromPrinter: true });
     const other    = filament(1, { idx: "GFA00", color: "#FFFFFF", amsId: null });
-    const slots = [spool("A0", { id: 1, idx: "GFA00", color: "FFFFFF", tag: true }), spool("A1", { id: 2, idx: "GFA00", color: "FFFFFF", tag: true })];
+    const slots = [spool("A1", { id: 1, idx: "GFA00", color: "FFFFFF", tag: true }), spool("A2", { id: 2, idx: "GFA00", color: "FFFFFF", tag: true })];
 
     const matched = matchConsumption([remapped, other], slots);
-    assert.equal(matched.get(remapped)[0].amsId, "A1");
-    assert.deepEqual(matched.get(other).map(c => c.amsId), ["A0"]);
+    assert.equal(matched.get(remapped)[0].amsId, "A2");
+    assert.deepEqual(matched.get(other).map(c => c.amsId), ["A1"]);
 });
 
 test("the filament identity stage separates a gradient spool from the plain one", () => {
@@ -158,11 +158,11 @@ test("the filament identity stage separates a gradient spool from the plain one"
     // entry, so nothing ever hit and only the loosest stage did any work.
     const gradient = filament(0, { idx: "GFA00", color: "#8EC9E9", colors: ["#8EC9E9", "#E7C1D5"] });
     const slots = [
-        spool("A0", { id: 1, idx: "GFA00", color: "8EC9E9", tag: true }),
-        spool("A1", { id: 2, idx: "GFA00", color: "8EC9E9", cols: ["8EC9E9", "E7C1D5"], tag: true }),
+        spool("A1", { id: 1, idx: "GFA00", color: "8EC9E9", tag: true }),
+        spool("A2", { id: 2, idx: "GFA00", color: "8EC9E9", cols: ["8EC9E9", "E7C1D5"], tag: true }),
     ];
 
-    assert.equal(matchedSlot([gradient], slots, gradient), "A1");
+    assert.equal(matchedSlot([gradient], slots, gradient), "A2");
 });
 
 test("a 3rd party spool is matched on material and colour", () => {
@@ -182,35 +182,35 @@ test("a profile two filaments of the print share matches nothing on its own", ()
     // honest answer.
     const black = filament(0, { idx: "GFA00", color: "#000000" });
     const white = filament(1, { idx: "GFA00", color: "#FFFFFF" });
-    const slots = [spool("A0", { id: 1, idx: "GFA00", color: "000000", tag: true })];
+    const slots = [spool("A1", { id: 1, idx: "GFA00", color: "000000", tag: true })];
 
     const matched = matchConsumption([black, white], slots);
-    assert.equal(matched.get(black)[0].amsId, "A0");
+    assert.equal(matched.get(black)[0].amsId, "A1");
     assert.deepEqual(matched.get(white), []);
 });
 
 test("a unique profile still matches when the colours do not line up", () => {
     const sliced = filament(0, { idx: "GFB01", color: "#123456", type: "ABS" });
-    const slots = [spool("A2", { id: 3, idx: "GFB01", type: "ABS", color: "FFFFFF", tag: true })];
+    const slots = [spool("A3", { id: 3, idx: "GFB01", type: "ABS", color: "FFFFFF", tag: true })];
 
-    assert.equal(matchedSlot([sliced], slots, sliced), "A2");
+    assert.equal(matchedSlot([sliced], slots, sliced), "A3");
 });
 
 test("a manual assignment outranks an automatic match in the same stage", () => {
     const sliced = filament(0, { idx: "GFA00", color: "#000000" });
     const slots = [
-        spool("A0", { id: 1, idx: "GFA00", color: "000000", tag: true }),
-        spool("A1", { id: 2, idx: "GFA00", color: "000000", mapped: true }),
+        spool("A1", { id: 1, idx: "GFA00", color: "000000", tag: true }),
+        spool("A2", { id: 2, idx: "GFA00", color: "000000", mapped: true }),
     ];
 
-    assert.equal(matchedSlot([sliced], slots, sliced), "A1");
+    assert.equal(matchedSlot([sliced], slots, sliced), "A2");
 });
 
 test("two indistinguishable spools are both reported, for the caller to decide", () => {
     const sliced = filament(0, { idx: "GFA00", color: "#000000" });
     const slots = [
-        spool("A0", { id: 1, idx: "GFA00", color: "000000", tag: true }),
-        spool("A1", { id: 2, idx: "GFA00", color: "000000", tag: true }),
+        spool("A1", { id: 1, idx: "GFA00", color: "000000", tag: true }),
+        spool("A2", { id: 2, idx: "GFA00", color: "000000", tag: true }),
     ];
 
     assert.deepEqual(matchConsumption([sliced], slots).get(sliced).map(c => c.id), [1, 2]);
@@ -229,13 +229,13 @@ test("the runtime slot and its client projection produce the same candidate", ()
     // them from toClientSpool(), which has already turned that into null. Two
     // keys for one slot would be exactly the drift this function exists to end.
     const runtime = consumptionCandidate({
-        amsId: "A0",
+        amsId: "A1",
         connectedViaMapping: true,
         existingSpool: { id: 5 },
         slot: { tray_info_idx: "N/A", tray_type: "PLA", tray_color: "F98C36", cols: ["F98C36"] },
     });
     const projected = consumptionCandidate({
-        amsId: "A0",
+        amsId: "A1",
         connectedViaMapping: true,
         existingSpool: { id: 5 },
         slot: { tray_info_idx: null, tray_type: "PLA", tray_color: "f98c36", cols: ["f98c36"] },

--- a/test/anonymize.test.js
+++ b/test/anonymize.test.js
@@ -96,7 +96,7 @@ test("the generic pattern leaves the RFID tag of a spool alone", () => {
     // 32 characters with no word boundary inside, so no 15 character run of it
     // can match. The tag identifies a piece of filament, not a person.
     const uuid = "18F1DE9B4FF74902A7CAA100D8F2CB5F";
-    assert.equal(maskText(`[A0] PLA Basic 000000FF [[ ${uuid} ]]`, {}), `[A0] PLA Basic 000000FF [[ ${uuid} ]]`);
+    assert.equal(maskText(`[A1] PLA Basic 000000FF [[ ${uuid} ]]`, {}), `[A1] PLA Basic 000000FF [[ ${uuid} ]]`);
 });
 
 test("every address in a log is masked, configured or not", () => {

--- a/test/diagnostics.test.js
+++ b/test/diagnostics.test.js
@@ -77,6 +77,22 @@ test("nothing identifying survives the anonymised bundle", async () => {
     assert.match(everything, /192\.168\.178\.XXX/);
 });
 
+test("the mapping file keeps its wrapper and loses only the serial", async () => {
+    // The assignments sit under "printers" with the schema version beside them,
+    // and masking the top level would have renamed those two rather than the
+    // serials one level down
+    fs.writeFileSync(
+        path.join(process.env.DATA_DIR, "mappings.json"),
+        JSON.stringify({ schemaVersion: 1, printers: { "01P00A000000042": { A1: { spoolId: 3 } } } }),
+    );
+
+    const mappings = JSON.parse((await bundle())["mappings.json"]);
+
+    assert.equal(mappings.schemaVersion, 1);
+    assert.deepEqual(Object.keys(mappings.printers), ["01P00XXXXXXXXXX"]);
+    assert.equal(mappings.printers["01P00XXXXXXXXXX"].A1.spoolId, 3);
+});
+
 test("the serial is masked in the log file names as well", async () => {
     const files = await bundle();
 

--- a/test/gcode.test.js
+++ b/test/gcode.test.js
@@ -76,13 +76,13 @@ test("full consumption matches the total weight the slicer reported", () => {
 test("two filaments sharing a profile are kept apart", () => {
     // Both 3rd party spools report the generic GFL99, so nothing but where they
     // sit separates them from each other. Filament ids 2 and 3 are the second
-    // and third entry of the slicer's list, which is A1 and A2.
+    // and third entry of the slicer's list, which is A2 and A3.
     const full = resolveSliceSlots(calcFullConsumption(fourColours), twoUnits);
     const bySlot = Object.fromEntries(Object.values(full).map(e => [e.amsId, e]));
-    assert.equal(bySlot["A1"].grams, 3.29);
-    assert.equal(bySlot["A2"].grams, 2.51);
-    assert.equal(bySlot["A1"].tray_info_idx, "GFL99");
-    assert.equal(bySlot["A2"].color, "#F98C36");
+    assert.equal(bySlot["A2"].grams, 3.29);
+    assert.equal(bySlot["A3"].grams, 2.51);
+    assert.equal(bySlot["A2"].tray_info_idx, "GFL99");
+    assert.equal(bySlot["A3"].color, "#F98C36");
 });
 
 test("non-contiguous filament ids still index the right layer ranges", () => {
@@ -99,8 +99,8 @@ test("a cancelled print books only the filaments that already ran", () => {
     // the next one. Both black, which is exactly the pair a colour key merged.
     const part = resolveSliceSlots(calcPartialConsumption(sparseIds, 84), twoUnits);
     const bySlot = Object.fromEntries(Object.values(part).map(e => [e.amsId, e]));
-    assert.equal(bySlot["A0"].grams, 7.76);
-    assert.equal(bySlot["B1"].grams, 0);
+    assert.equal(bySlot["A1"].grams, 7.76);
+    assert.equal(bySlot["B2"].grams, 0);
 });
 
 test("a filament that pauses and resumes is scaled over its own layers only", () => {
@@ -209,32 +209,32 @@ test("the three multi colour filaments are still told apart", () => {
 /* ---- The slot a filament was sliced for ---- */
 
 // Two AMS units, which is what both real prints below were sliced against.
-const twoUnits = ["A0", "A1", "A2", "A3", "B0", "B1", "B2", "B3"];
+const twoUnits = ["A1", "A2", "A3", "A4", "B1", "B2", "B3", "B4"];
 
 test("the slots are ordered by ascending AMS unit id", () => {
     // Reported in whatever order the printer sends its units, and the slicer
     // lists them unit by unit and slot by slot.
-    assert.deepEqual(orderedAmsSlots(["B1", "A0", "B0", "A2"]),
-                     ["A0", "A1", "A2", "A3", "B0", "B1", "B2", "B3"]);
+    assert.deepEqual(orderedAmsSlots(["B2", "A1", "B1", "A3"]),
+                     ["A1", "A2", "A3", "A4", "B1", "B2", "B3", "B4"]);
 
     // Every attached four slot unit contributes all four positions even when
     // only some of them reported. The slicer lists a slot whether or not it
     // holds anything, so counting the reported ones would shift everything
     // after an empty slot.
-    assert.deepEqual(orderedAmsSlots(["A0"]), ["A0", "A1", "A2", "A3"]);
+    assert.deepEqual(orderedAmsSlots(["A1"]), ["A1", "A2", "A3", "A4"]);
 
     // The printer numbers the four slot units 0 to 3, an AMS HT 128 to 135 and
     // the external holder 255, so both sit after them and the holder last.
-    assert.deepEqual(orderedAmsSlots(["A0", "External", "HT-B", "HT-A"]),
-                     ["A0", "A1", "A2", "A3", "HT-A", "HT-B", "External"]);
+    assert.deepEqual(orderedAmsSlots(["A1", "External", "HT-B", "HT-A"]),
+                     ["A1", "A2", "A3", "A4", "HT-A", "HT-B", "External"]);
     assert.deepEqual(orderedAmsSlots([]), []);
 });
 
 test("the real multi colour print resolves to the slots it was printed from", () => {
-    // Verified against the printer: ids 5, 7 and 8 were B0, B2 and B3.
+    // Verified against the printer: ids 5, 7 and 8 were B1, B3 and B4.
     const full = resolveSliceSlots(calcFullConsumption(multiColour), twoUnits);
     assert.deepEqual(Object.values(full).map(e => [e.amsId, e.grams]), [
-        ["B0", 156.24], ["B2", 49.64], ["B3", 66.27],
+        ["B1", 156.24], ["B3", 49.64], ["B4", 66.27],
     ]);
 });
 
@@ -242,12 +242,12 @@ test("a spool on the external holder gets the position after the AMS units", () 
     // The file that settled the ordering: the same printer with a spool on the
     // external holder lists nine filaments, and its ninth colour is the one the
     // printer reports for the holder. Arithmetic on four slots per unit turned
-    // that into "C0", a unit this printer does not have.
+    // that into "C1", a unit this printer does not have.
     const full = resolveSliceSlots(calcFullConsumption(externalSpool),
                                    orderedAmsSlots([...twoUnits, "External"]));
     assert.deepEqual(Object.values(full).map(e => [e.index, e.amsId, e.grams]), [
-        [3, "A3", 30.49],
-        [4, "B0", 67.29],
+        [3, "A4", 30.49],
+        [4, "B1", 67.29],
         [8, "External", 80.92],
     ]);
 });
@@ -257,7 +257,7 @@ test("an empty holder leaves the position after the AMS units unfilled", () => {
     // ninth filament of that same file has nowhere to go and falls through to
     // the stages that match on profile and colour.
     const full = resolveSliceSlots(calcFullConsumption(externalSpool), orderedAmsSlots(twoUnits));
-    assert.deepEqual(Object.values(full).map(e => e.amsId), ["A3", "B0", null]);
+    assert.deepEqual(Object.values(full).map(e => e.amsId), ["A4", "B1", null]);
 });
 
 test("the list length says nothing about the printer's layout", () => {
@@ -265,7 +265,7 @@ test("the list length says nothing about the printer's layout", () => {
     // count is the project's and not the printer's. Resolving against six slots
     // simply leaves everything past them unplaced.
     const full = resolveSliceSlots(calcFullConsumption(externalSpool), twoUnits.slice(0, 6));
-    assert.deepEqual(Object.values(full).map(e => e.amsId), ["A3", "B0", null]);
+    assert.deepEqual(Object.values(full).map(e => e.amsId), ["A4", "B1", null]);
 });
 
 /* ---- The colour set out of project_settings.config ---- */
@@ -342,8 +342,8 @@ test("two identical spools in different slots are no longer added together", () 
 
     const full = resolveSliceSlots(calcFullConsumption(twoBlacks), twoUnits);
     const bySlot = Object.fromEntries(Object.values(full).map(e => [e.amsId, e]));
-    assert.equal(bySlot["A0"].grams, 120);
-    assert.equal(bySlot["A1"].grams, 45);
+    assert.equal(bySlot["A1"].grams, 120);
+    assert.equal(bySlot["A2"].grams, 45);
 });
 
 test("a filament beyond the printer's slots keeps its figures and no slot", () => {
@@ -367,15 +367,15 @@ test("a filament beyond the printer's slots keeps its figures and no slot", () =
 
 test("the printer's own mapping names the slots it is printing from", () => {
     // A project of three filaments on a printer with two AMS units. The slicer
-    // list order would have said A0, A1 and A2, and none of those was right.
-    assert.deepEqual(decodePrintMapping([256, 2, 259]), ["B0", "A2", "B3"]);
+    // list order would have said A1, A2 and A3, and none of those was right.
+    assert.deepEqual(decodePrintMapping([256, 2, 259]), ["B1", "A3", "B4"]);
 });
 
 test("the mapping carries the external holder and the filaments left unused", () => {
     // 0xFF00 is unit 255, which is the holder. 0xFFFF is the marker for a
     // filament of the project that this plate does not print, and decoding it
     // as a unit and a slot would read as the holder too.
-    assert.deepEqual(decodePrintMapping([256, 2, 65535, 65280]), ["B0", "A2", null, "External"]);
+    assert.deepEqual(decodePrintMapping([256, 2, 65535, 65280]), ["B1", "A3", null, "External"]);
 });
 
 test("a printer that reports no mapping says so", () => {
@@ -420,6 +420,6 @@ test("the mapping drops into the same resolution as the list order", () => {
     const full = resolveSliceSlots(calcFullConsumption(externalSpool),
                                    decodePrintMapping([65535, 65535, 65535, 256, 2, 65535, 65535, 65535, 65280]));
     assert.deepEqual(Object.values(full).map(e => [e.index, e.amsId]), [
-        [3, "B0"], [4, "A2"], [8, "External"],
+        [3, "B1"], [4, "A3"], [8, "External"],
     ]);
 });

--- a/test/location.test.js
+++ b/test/location.test.js
@@ -72,13 +72,13 @@ after(() => new Promise(resolve => server.close(resolve)));
 // ---------------------------------------------------------------------------
 
 test("the location is the printer name and the slot label", () => {
-    assert.equal(slotLocation("X1C", "A0"), "X1C - A0");
+    assert.equal(slotLocation("X1C", "A1"), "X1C - A1");
     assert.equal(slotLocation("X1C", "External"), "X1C - External");
     assert.equal(slotLocation("X1C", "HT-A"), "X1C - HT-A");
 });
 
 test("a location this printer wrote is ours, whichever slot it names", () => {
-    assert.equal(ownsLocation("X1C - A0", "X1C"), true);
+    assert.equal(ownsLocation("X1C - A1", "X1C"), true);
     assert.equal(ownsLocation("X1C - HT-B", "X1C"), true);
 });
 
@@ -91,8 +91,8 @@ test("a location the user set by hand is not ours", () => {
 });
 
 test("a location of a printer with a similar name is not ours", () => {
-    assert.equal(ownsLocation("P1S - A0", "P1"), false);
-    assert.equal(ownsLocation("P1 - A0", "P1S"), false);
+    assert.equal(ownsLocation("P1S - A1", "P1"), false);
+    assert.equal(ownsLocation("P1 - A1", "P1S"), false);
 });
 
 // ---------------------------------------------------------------------------
@@ -102,17 +102,17 @@ test("a location of a printer with a similar name is not ours", () => {
 test("claiming a slot writes the location", async () => {
     const spool = seed(1);
 
-    assert.equal(await claimSlotLocation(printer, "A0", spool), true);
-    assert.deepEqual(patches, [{ id: 1, payload: { location: "Test Printer - A0" } }]);
+    assert.equal(await claimSlotLocation(printer, "A1", spool), true);
+    assert.deepEqual(patches, [{ id: 1, payload: { location: "Test Printer - A1" } }]);
     // The caller's record is reused for the rest of the update, so it has to
     // carry what was written.
-    assert.equal(spool.location, "Test Printer - A0");
+    assert.equal(spool.location, "Test Printer - A1");
 });
 
 test("claiming a slot that already says so writes nothing", async () => {
-    const spool = seed(1, "Test Printer - A0");
+    const spool = seed(1, "Test Printer - A1");
 
-    assert.equal(await claimSlotLocation(printer, "A0", spool), false);
+    assert.equal(await claimSlotLocation(printer, "A1", spool), false);
     assert.deepEqual(patches, []);
 });
 
@@ -121,12 +121,12 @@ test("claiming corrects a location that was changed in Spoolman", async () => {
     // filament identity changed, so a location edited in Spoolman stayed wrong.
     const spool = seed(1, "Somewhere else");
 
-    assert.equal(await claimSlotLocation(printer, "A0", spool), true);
-    assert.equal(patches[0].payload.location, "Test Printer - A0");
+    assert.equal(await claimSlotLocation(printer, "A1", spool), true);
+    assert.equal(patches[0].payload.location, "Test Printer - A1");
 });
 
 test("releasing clears a location this printer wrote", async () => {
-    const spool = seed(1, "Test Printer - A0");
+    const spool = seed(1, "Test Printer - A1");
 
     assert.equal(await releaseSlotLocation(printer, spool), true);
     assert.deepEqual(patches, [{ id: 1, payload: { location: "" } }]);
@@ -141,7 +141,7 @@ test("releasing leaves a location the user set alone", async () => {
 });
 
 test("releasing leaves another printer's location alone", async () => {
-    const spool = seed(1, "Other Printer - A0");
+    const spool = seed(1, "Other Printer - A1");
 
     assert.equal(await releaseSlotLocation(printer, spool), false);
     assert.deepEqual(patches, []);
@@ -149,27 +149,27 @@ test("releasing leaves another printer's location alone", async () => {
 
 test("nothing is written while the setting is off", async () => {
     settings.SET_LOCATION = false;
-    const spool = seed(1, "Test Printer - A0");
+    const spool = seed(1, "Test Printer - A1");
 
-    assert.equal(await claimSlotLocation(printer, "A0", seed(2)), false);
+    assert.equal(await claimSlotLocation(printer, "A1", seed(2)), false);
     assert.equal(await releaseSlotLocation(printer, spool), false);
     assert.deepEqual(patches, []);
 });
 
 test("a slot without a spool writes nothing", async () => {
-    assert.equal(await claimSlotLocation(printer, "A0", null), false);
+    assert.equal(await claimSlotLocation(printer, "A1", null), false);
     assert.equal(await releaseSlotLocation(printer, null), false);
     assert.deepEqual(patches, []);
 });
 
 test("a failing Spoolman is logged, not thrown", async () => {
     const unreachable = { ...printer };
-    const spool = { id: 999, location: "Test Printer - A0" };
+    const spool = { id: 999, location: "Test Printer - A1" };
     spools.delete(999);
 
     settings.SPOOLMAN_ENDPOINT = "http://127.0.0.1:1";
     try {
-        assert.equal(await claimSlotLocation(unreachable, "A0", { id: 999 }), false);
+        assert.equal(await claimSlotLocation(unreachable, "A1", { id: 999 }), false);
         assert.equal(await releaseSlotLocation(unreachable, spool), false);
     } finally {
         settings.SPOOLMAN_ENDPOINT = `http://127.0.0.1:${server.address().port}`;
@@ -181,32 +181,32 @@ test("a failing Spoolman is logged, not thrown", async () => {
 // ---------------------------------------------------------------------------
 
 test("a spool that changed slot keeps its location", async () => {
-    // The regression this exists for: A0 is processed before A1, so the slot the
+    // The regression this exists for: A1 is processed before A2, so the slot the
     // spool moved into wrote the new location and the slot it left cleared it
     // again one slot later.
-    const spool = seed(1, "Test Printer - A1");
+    const spool = seed(1, "Test Printer - A2");
     const sync = createLocationSync(printer);
 
-    sync.claim("A0", spool);   // it is here now
-    sync.release(spool);       // A1 reports it gone
-    await sync.flush();
-
-    assert.deepEqual(patches, [{ id: 1, payload: { location: "Test Printer - A0" } }]);
-});
-
-test("the slot order does not decide the outcome of a move", async () => {
-    const spool = seed(1, "Test Printer - A0");
-    const sync = createLocationSync(printer);
-
-    sync.release(spool);       // A0 reports it gone
-    sync.claim("A1", spool);   // it turns up in A1
+    sync.claim("A1", spool);   // it is here now
+    sync.release(spool);       // A2 reports it gone
     await sync.flush();
 
     assert.deepEqual(patches, [{ id: 1, payload: { location: "Test Printer - A1" } }]);
 });
 
+test("the slot order does not decide the outcome of a move", async () => {
+    const spool = seed(1, "Test Printer - A1");
+    const sync = createLocationSync(printer);
+
+    sync.release(spool);       // A1 reports it gone
+    sync.claim("A2", spool);   // it turns up in A2
+    await sync.flush();
+
+    assert.deepEqual(patches, [{ id: 1, payload: { location: "Test Printer - A2" } }]);
+});
+
 test("a spool taken out of the AMS is released", async () => {
-    const spool = seed(1, "Test Printer - A0");
+    const spool = seed(1, "Test Printer - A1");
     const sync = createLocationSync(printer);
 
     sync.release(spool);
@@ -216,18 +216,18 @@ test("a spool taken out of the AMS is released", async () => {
 });
 
 test("a slot whose spool was swapped releases the old one and claims the new", async () => {
-    const removed = seed(1, "Test Printer - A0");
+    const removed = seed(1, "Test Printer - A1");
     const inserted = seed(2);
     const sync = createLocationSync(printer);
 
-    sync.claim("A0", inserted);
+    sync.claim("A1", inserted);
     sync.release(removed);
     await sync.flush();
 
     // Claims first: a spool that is physically in the AMS must never be left
     // without a location, not even between two requests.
     assert.deepEqual(patches, [
-        { id: 2, payload: { location: "Test Printer - A0" } },
+        { id: 2, payload: { location: "Test Printer - A1" } },
         { id: 1, payload: { location: "" } },
     ]);
 });
@@ -236,8 +236,8 @@ test("a flush writes nothing while the setting is off", async () => {
     settings.SET_LOCATION = false;
     const sync = createLocationSync(printer);
 
-    sync.claim("A0", seed(1));
-    sync.release(seed(2, "Test Printer - A1"));
+    sync.claim("A1", seed(1));
+    sync.release(seed(2, "Test Printer - A2"));
     await sync.flush();
 
     assert.deepEqual(patches, []);
@@ -248,11 +248,11 @@ test("a flush writes nothing while the setting is off", async () => {
 // ---------------------------------------------------------------------------
 
 test("removing a printer gives its slots' locations back", async () => {
-    seed(1, "Test Printer - A0");
+    seed(1, "Test Printer - A1");
     seed(2, "Shelf A");
     printer.spoolData = [
-        { amsId: "A0", connectedViaTag: true, existingSpool: { id: 1 } },
-        { amsId: "A1", connectedViaMapping: true, existingSpool: { id: 2 } },
+        { amsId: "A1", connectedViaTag: true, existingSpool: { id: 1 } },
+        { amsId: "A2", connectedViaMapping: true, existingSpool: { id: 2 } },
     ];
 
     await releasePrinterLocations(printer);
@@ -262,8 +262,8 @@ test("removing a printer gives its slots' locations back", async () => {
 });
 
 test("removing a printer ignores slots that only hold a merge candidate", async () => {
-    seed(1, "Test Printer - A0");
-    printer.spoolData = [{ amsId: "A0", existingSpool: { id: 1 } }];
+    seed(1, "Test Printer - A1");
+    printer.spoolData = [{ amsId: "A1", existingSpool: { id: 1 } }];
 
     await releasePrinterLocations(printer);
 
@@ -271,25 +271,25 @@ test("removing a printer ignores slots that only hold a merge candidate", async 
 });
 
 test("renaming a printer rewrites the locations it had written", async () => {
-    seed(1, "Old Name - A0");
+    seed(1, "Old Name - A1");
     seed(2, "Shelf A");
     printer.spoolData = [
-        { amsId: "A0", connectedViaTag: true, existingSpool: { id: 1 } },
-        { amsId: "A1", connectedViaTag: true, existingSpool: { id: 2 } },
+        { amsId: "A1", connectedViaTag: true, existingSpool: { id: 1 } },
+        { amsId: "A2", connectedViaTag: true, existingSpool: { id: 2 } },
     ];
     printer.name = "New Name";
 
     await renamePrinterLocations(printer, "Old Name");
 
-    assert.deepEqual(patches, [{ id: 1, payload: { location: "New Name - A0" } }]);
+    assert.deepEqual(patches, [{ id: 1, payload: { location: "New Name - A1" } }]);
 });
 
 test("a rename reads the location from Spoolman, not from the cached slot", async () => {
     // The cached record is whatever Spoolman said when it was fetched, and the
     // decision depends on what it says now.
-    seed(1, "Old Name - A0");
+    seed(1, "Old Name - A1");
     printer.spoolData = [{
-        amsId: "A0",
+        amsId: "A1",
         connectedViaTag: true,
         existingSpool: { id: 1, location: "something stale" },
     }];
@@ -297,5 +297,5 @@ test("a rename reads the location from Spoolman, not from the cached slot", asyn
 
     await renamePrinterLocations(printer, "Old Name");
 
-    assert.deepEqual(patches, [{ id: 1, payload: { location: "New Name - A0" } }]);
+    assert.deepEqual(patches, [{ id: 1, payload: { location: "New Name - A1" } }]);
 });

--- a/test/mappings.test.js
+++ b/test/mappings.test.js
@@ -6,7 +6,7 @@ import path from "path";
 
 // The module reads its path from config.js at import time, so DATA_DIR has to
 // point at a throwaway directory before the first import.
-let dir, mappingsPath, getMapping, setMapping, slotFingerprint;
+let dir, mappingsPath, getMapping, setMapping, slotFingerprint, migrateStored, parseStoredFile;
 
 before(async () => {
     dir = fs.mkdtempSync(path.join(os.tmpdir(), "ams-map-"));
@@ -16,7 +16,7 @@ before(async () => {
     fs.ensureDirSync(process.env.LOG_DIR);
 
     ({ mappingsPath } = await import("../src/config.js"));
-    ({ getMapping, setMapping, slotFingerprint } = await import("../src/mappings.js"));
+    ({ getMapping, setMapping, slotFingerprint, migrateStored, parseStoredFile } = await import("../src/mappings.js"));
 });
 after(() => fs.removeSync(dir));
 
@@ -27,7 +27,10 @@ const slot = (overrides = {}) => ({
     ...overrides,
 });
 
-const stored = () => JSON.parse(fs.readFileSync(mappingsPath, "utf-8"));
+const stored = () => JSON.parse(fs.readFileSync(mappingsPath, "utf-8")).printers;
+
+/** Writes a mapping file in the current shape, which is the migrated one. */
+const writeStored = printers => fs.outputFileSync(mappingsPath, JSON.stringify({ schemaVersion: 1, printers }));
 
 test("the fingerprint carries the filament profile as well as material and colour", () => {
     assert.equal(slotFingerprint(slot()), "GFA00|PLA|F98C36");
@@ -45,45 +48,45 @@ test("a spool swap that keeps material and colour is noticed", () => {
     // The case this exists for: two spools that only the filament profile tells
     // apart. Keyed on material and colour alone the assignment survived the
     // swap and the next print was booked onto the wrong spool.
-    setMapping("P1", "A0", 42, slot());
+    setMapping("P1", "A1", 42, slot());
 
-    const swapped = getMapping("P1", "A0", slot({ tray_info_idx: "GFA01" }));
+    const swapped = getMapping("P1", "A1", slot({ tray_info_idx: "GFA01" }));
 
     assert.equal(swapped, null);
     assert.equal(stored().P1, undefined);
 });
 
 test("the same spool keeps its assignment", () => {
-    setMapping("P2", "A0", 7, slot());
+    setMapping("P2", "A1", 7, slot());
 
-    assert.equal(getMapping("P2", "A0", slot()).spoolId, 7);
+    assert.equal(getMapping("P2", "A1", slot()).spoolId, 7);
     // A colour that differs only in the alpha byte is the same spool
-    assert.equal(getMapping("P2", "A0", slot({ tray_color: "F98C3600" })).spoolId, 7);
+    assert.equal(getMapping("P2", "A1", slot({ tray_color: "F98C3600" })).spoolId, 7);
 });
 
 test("a fingerprint from before the profile was included still matches, and is rewritten", async () => {
     // Existing installs have these on disk and there is no migration step, so
     // an upgrade must not silently drop every assignment
-    fs.outputFileSync(mappingsPath, JSON.stringify({
-        P3: { A0: { spoolId: 5, fingerprint: "PLA|F98C36", updatedAt: "2026-08-01T00:00:00.000Z" } },
-    }));
+    writeStored({
+        P3: { A1: { spoolId: 5, fingerprint: "PLA|F98C36", updatedAt: "2026-08-01T00:00:00.000Z" } },
+    });
     // Drop the module cache so the file above is the state it loads
     const { getMapping: freshGetMapping } = await import(`../src/mappings.js?legacy=${Date.now()}`);
 
-    const entry = freshGetMapping("P3", "A0", slot());
+    const entry = freshGetMapping("P3", "A1", slot());
 
     assert.equal(entry.spoolId, 5);
     assert.equal(entry.fingerprint, "GFA00|PLA|F98C36");
-    assert.equal(stored().P3.A0.fingerprint, "GFA00|PLA|F98C36");
+    assert.equal(stored().P3.A1.fingerprint, "GFA00|PLA|F98C36");
 });
 
 test("an old fingerprint for a different filament is still dropped", async () => {
-    fs.outputFileSync(mappingsPath, JSON.stringify({
-        P4: { A0: { spoolId: 9, fingerprint: "PETG|1E88E5", updatedAt: "2026-08-01T00:00:00.000Z" } },
-    }));
+    writeStored({
+        P4: { A1: { spoolId: 9, fingerprint: "PETG|1E88E5", updatedAt: "2026-08-01T00:00:00.000Z" } },
+    });
     const { getMapping: freshGetMapping } = await import(`../src/mappings.js?stale=${Date.now()}`);
 
-    assert.equal(freshGetMapping("P4", "A0", slot()), null);
+    assert.equal(freshGetMapping("P4", "A1", slot()), null);
 });
 
 /* ---- Multi colour spools ---- */
@@ -113,21 +116,81 @@ test("the fingerprint carries the colour set of a multi colour spool", () => {
 });
 
 test("swapping one gradient for another drops the assignment", () => {
-    setMapping("P4", "A0", 11, gradient(["FFFFFF", "9CDBD9"]));
+    setMapping("P4", "A1", 11, gradient(["FFFFFF", "9CDBD9"]));
 
-    assert.equal(getMapping("P4", "A0", gradient(["FFFFFF", "9CDBD9"])).spoolId, 11);
-    assert.equal(getMapping("P4", "A0", gradient(["FFFFFF", "E94B3C"])), null);
+    assert.equal(getMapping("P4", "A1", gradient(["FFFFFF", "9CDBD9"])).spoolId, 11);
+    assert.equal(getMapping("P4", "A1", gradient(["FFFFFF", "E94B3C"])), null);
 });
 
 test("a fingerprint from before the colour set still matches, and is rewritten", async () => {
     // Same reasoning as the two part format above: an upgrade must not drop
     // every assignment that happens to sit on a multi colour spool.
-    fs.outputFileSync(mappingsPath, JSON.stringify({
-        P5: { A0: { spoolId: 9, fingerprint: "GFA00|PLA|FFFFFF", updatedAt: "2026-08-01T00:00:00.000Z" } },
-    }));
+    writeStored({
+        P5: { A1: { spoolId: 9, fingerprint: "GFA00|PLA|FFFFFF", updatedAt: "2026-08-01T00:00:00.000Z" } },
+    });
     const fresh = await import(`../src/mappings.js?colorset=${Date.now()}`);
 
     const slot = gradient(["FFFFFF", "9CDBD9"]);
-    assert.equal(fresh.getMapping("P5", "A0", slot).spoolId, 9);
-    assert.equal(stored().P5.A0.fingerprint, "GFA00|PLA|FFFFFF|9CDBD9+FFFFFF");
+    assert.equal(fresh.getMapping("P5", "A1", slot).spoolId, 9);
+    assert.equal(stored().P5.A1.fingerprint, "GFA00|PLA|FFFFFF|9CDBD9+FFFFFF");
+});
+
+/* ---- The slot labels of the file ---- */
+
+test("a file written before the slots counted from 1 is renumbered", () => {
+    const zeroBased = {
+        P6: {
+            A0: { spoolId: 1, fingerprint: "GFA00|PLA|000000", updatedAt: "2026-08-01T00:00:00.000Z" },
+            A3: { spoolId: 2, fingerprint: "GFA00|PLA|FFFFFF", updatedAt: "2026-08-01T00:00:00.000Z" },
+            "HT-A": { spoolId: 3, fingerprint: "GFA00|PLA|F98C36", updatedAt: "2026-08-01T00:00:00.000Z" },
+            External: { spoolId: 4, fingerprint: "GFA00|PLA|0ACC38", updatedAt: "2026-08-01T00:00:00.000Z" },
+        },
+        P7: { D3: { spoolId: 5, fingerprint: "GFA00|PLA|1E88E5", updatedAt: "2026-08-01T00:00:00.000Z" } },
+    };
+
+    const migrated = migrateStored(zeroBased, 0);
+
+    // Every slot keeps its spool and moves up by one, so the assignment still
+    // names the slot the user made it for
+    assert.deepEqual(Object.keys(migrated.P6), ["A1", "A4", "HT-A", "External"]);
+    assert.equal(migrated.P6.A1.spoolId, 1);
+    assert.equal(migrated.P6.A4.spoolId, 2);
+    // A unit with a single slot carries no number and is left alone
+    assert.equal(migrated.P6["HT-A"].spoolId, 3);
+    assert.equal(migrated.P6.External.spoolId, 4);
+    assert.deepEqual(Object.keys(migrated.P7), ["D4"]);
+});
+
+test("a file that already counts from 1 is left as it is", () => {
+    const oneBased = { P8: { A1: { spoolId: 1, fingerprint: "GFA00|PLA|000000", updatedAt: "2026-08-01T00:00:00.000Z" } } };
+
+    // The version is the only thing that separates the two, since "A1" is a
+    // valid key of both shapes and means a different slot in each
+    assert.deepEqual(migrateStored(oneBased, 1), oneBased);
+    assert.deepEqual(migrateStored(oneBased, 0).P8, { A2: oneBased.P8.A1 });
+});
+
+test("a flat file is read as the version that counted from 0", () => {
+    assert.deepEqual(parseStoredFile({ P9: { A0: { spoolId: 1 } } }),
+                     { printers: { P9: { A0: { spoolId: 1 } } }, schemaVersion: 0 });
+
+    // A wrapper without a version is one this build wrote, so nothing is
+    // renumbered under it
+    assert.deepEqual(parseStoredFile({ printers: { P9: {} } }), { printers: { P9: {} }, schemaVersion: 1 });
+    assert.deepEqual(parseStoredFile({ schemaVersion: 1, printers: { P9: {} } }),
+                     { printers: { P9: {} }, schemaVersion: 1 });
+});
+
+test("the assignments of a flat file survive a restart under their new labels", async () => {
+    fs.outputFileSync(mappingsPath, JSON.stringify({
+        P10: { A0: { spoolId: 12, fingerprint: "GFA00|PLA|F98C36", updatedAt: "2026-08-01T00:00:00.000Z" } },
+    }));
+    const fresh = await import(`../src/mappings.js?renumber=${Date.now()}`);
+
+    assert.equal(fresh.getMapping("P10", "A1", slot()).spoolId, 12);
+    assert.equal(fresh.getMapping("P10", "A0", slot()), null);
+    // Written back, so the next start reads a file that states what its labels
+    // mean rather than renumbering them again
+    assert.equal(JSON.parse(fs.readFileSync(mappingsPath, "utf-8")).schemaVersion, 1);
+    assert.equal(stored().P10.A1.spoolId, 12);
 });

--- a/test/mqtt.remain.test.js
+++ b/test/mqtt.remain.test.js
@@ -13,8 +13,8 @@ const slot = (remain, uuid = "A6A4F33B") => ({ remain, tray_uuid: uuid });
 test("a slot with a reading never waits, and clears an earlier wait", () => {
     const printer = { remainWaits: {} };
 
-    assert.equal(waitedLongEnoughForRemain(printer, "A0", slot(null)), false);
-    assert.equal(waitedLongEnoughForRemain(printer, "A0", slot(100)), true);
+    assert.equal(waitedLongEnoughForRemain(printer, "A1", slot(null)), false);
+    assert.equal(waitedLongEnoughForRemain(printer, "A1", slot(100)), true);
     assert.deepEqual(printer.remainWaits, {}, "the counter is dropped, not left to expire");
 });
 
@@ -22,30 +22,30 @@ test("a slot without a reading waits five updates, then gives up", () => {
     const printer = { remainWaits: {} };
 
     for (let update = 1; update <= 5; update++) {
-        assert.equal(waitedLongEnoughForRemain(printer, "A0", slot(null)), false, `update ${update}`);
+        assert.equal(waitedLongEnoughForRemain(printer, "A1", slot(null)), false, `update ${update}`);
     }
     // Better a spool stored as full than a spool never created at all, for a
     // chip that reports nothing.
-    assert.equal(waitedLongEnoughForRemain(printer, "A0", slot(null)), true);
+    assert.equal(waitedLongEnoughForRemain(printer, "A1", slot(null)), true);
 });
 
 test("a different spool in the same slot starts the wait over", () => {
     const printer = { remainWaits: {} };
 
-    for (let update = 1; update <= 5; update++) waitedLongEnoughForRemain(printer, "A0", slot(null));
-    assert.equal(waitedLongEnoughForRemain(printer, "A0", slot(null, "OTHER")), false);
-    assert.equal(printer.remainWaits.A0.waits, 1);
+    for (let update = 1; update <= 5; update++) waitedLongEnoughForRemain(printer, "A1", slot(null));
+    assert.equal(waitedLongEnoughForRemain(printer, "A1", slot(null, "OTHER")), false);
+    assert.equal(printer.remainWaits.A1.waits, 1);
 });
 
 test("slots are counted apart", () => {
     const printer = { remainWaits: {} };
 
-    for (let update = 1; update <= 6; update++) waitedLongEnoughForRemain(printer, "A0", slot(null));
-    assert.equal(waitedLongEnoughForRemain(printer, "A1", slot(null, "B19E8E14")), false);
+    for (let update = 1; update <= 6; update++) waitedLongEnoughForRemain(printer, "A1", slot(null));
+    assert.equal(waitedLongEnoughForRemain(printer, "A2", slot(null, "B19E8E14")), false);
 });
 
 test("a printer created before the counter existed does not crash", () => {
     const printer = {};
-    assert.equal(waitedLongEnoughForRemain(printer, "A0", slot(null)), false);
-    assert.deepEqual(printer.remainWaits, { A0: { uuid: "A6A4F33B", waits: 1 } });
+    assert.equal(waitedLongEnoughForRemain(printer, "A1", slot(null)), false);
+    assert.deepEqual(printer.remainWaits, { A1: { uuid: "A6A4F33B", waits: 1 } });
 });

--- a/test/routes.mappings.location.test.js
+++ b/test/routes.mappings.location.test.js
@@ -74,10 +74,10 @@ function seed(id, location = null) {
     return spools.get(id);
 }
 
-/** Points the cached slot A0 at a spool, the way an AMS update would. */
+/** Points the cached slot A1 at a spool, the way an AMS update would. */
 function slotHolds(spool) {
     printer.spoolData = [{
-        amsId: "A0",
+        amsId: "A1",
         slotState: "Loaded (3rd party)",
         slot: { tray_uuid: "N/A", tray_type: "PLA", tray_color: "FF0000FF" },
         existingSpool: spool ? { ...spool } : null,
@@ -90,29 +90,29 @@ beforeEach(async () => {
     patches.length = 0;
     spools.clear();
     slotHolds(null);
-    await call(`${app.url}/api/mappings/${SERIAL}/A0`, "DELETE");
+    await call(`${app.url}/api/mappings/${SERIAL}/A1`, "DELETE");
     patches.length = 0;
 });
 
 test("assigning a spool writes the slot as its location", async () => {
     seed(1);
 
-    const { status } = await call(`${app.url}/api/mappings/${SERIAL}/A0`, "PUT", { spoolId: 1 });
+    const { status } = await call(`${app.url}/api/mappings/${SERIAL}/A1`, "PUT", { spoolId: 1 });
 
     assert.equal(status, 200);
-    assert.deepEqual(patches, [{ id: 1, payload: { location: "Test Printer - A0" } }]);
+    assert.deepEqual(patches, [{ id: 1, payload: { location: "Test Printer - A1" } }]);
 });
 
 test("unassigning a spool clears the location again", async () => {
-    const spool = seed(1, "Test Printer - A0");
+    const spool = seed(1, "Test Printer - A1");
     slotHolds(spool);
 
-    const { status, body } = await call(`${app.url}/api/mappings/${SERIAL}/A0`, "PUT", { spoolId: 1 });
+    const { status, body } = await call(`${app.url}/api/mappings/${SERIAL}/A1`, "PUT", { spoolId: 1 });
     assert.equal(status, 200);
     assert.ok(body.ok);
     patches.length = 0;
 
-    const removed = await call(`${app.url}/api/mappings/${SERIAL}/A0`, "DELETE");
+    const removed = await call(`${app.url}/api/mappings/${SERIAL}/A1`, "DELETE");
 
     assert.equal(removed.status, 200);
     assert.equal(removed.body.removed, true);
@@ -122,38 +122,38 @@ test("unassigning a spool clears the location again", async () => {
 test("unassigning leaves a location the user set by hand alone", async () => {
     const spool = seed(1, "Shelf A");
     slotHolds(spool);
-    await call(`${app.url}/api/mappings/${SERIAL}/A0`, "PUT", { spoolId: 1 });
+    await call(`${app.url}/api/mappings/${SERIAL}/A1`, "PUT", { spoolId: 1 });
     // The assignment claimed the slot, so put the hand-set location back the way
     // a user editing it in Spoolman afterwards would.
     spools.get(1).location = "Shelf A";
     slotHolds(spools.get(1));
     patches.length = 0;
 
-    await call(`${app.url}/api/mappings/${SERIAL}/A0`, "DELETE");
+    await call(`${app.url}/api/mappings/${SERIAL}/A1`, "DELETE");
 
     assert.deepEqual(patches, []);
     assert.equal(spools.get(1).location, "Shelf A");
 });
 
 test("reassigning a slot moves the location from the old spool to the new one", async () => {
-    const previous = seed(1, "Test Printer - A0");
+    const previous = seed(1, "Test Printer - A1");
     seed(2);
     slotHolds(previous);
-    await call(`${app.url}/api/mappings/${SERIAL}/A0`, "PUT", { spoolId: 1 });
+    await call(`${app.url}/api/mappings/${SERIAL}/A1`, "PUT", { spoolId: 1 });
     patches.length = 0;
 
-    await call(`${app.url}/api/mappings/${SERIAL}/A0`, "PUT", { spoolId: 2 });
+    await call(`${app.url}/api/mappings/${SERIAL}/A1`, "PUT", { spoolId: 2 });
 
     assert.deepEqual(patches, [
         { id: 1, payload: { location: "" } },
-        { id: 2, payload: { location: "Test Printer - A0" } },
+        { id: 2, payload: { location: "Test Printer - A1" } },
     ]);
 });
 
 test("unassigning a slot that had nothing assigned writes nothing", async () => {
-    seed(1, "Test Printer - A0");
+    seed(1, "Test Printer - A1");
 
-    const { status, body } = await call(`${app.url}/api/mappings/${SERIAL}/A0`, "DELETE");
+    const { status, body } = await call(`${app.url}/api/mappings/${SERIAL}/A1`, "DELETE");
 
     assert.equal(status, 200);
     assert.equal(body.removed, false);
@@ -163,7 +163,7 @@ test("unassigning a slot that had nothing assigned writes nothing", async () => 
 test("a rejected assignment writes no location", async () => {
     // Spool 7 is not in Spoolman, so the route answers 404 before anything is
     // stored, and nothing may have been written on the way there either.
-    const { status } = await call(`${app.url}/api/mappings/${SERIAL}/A0`, "PUT", { spoolId: 7 });
+    const { status } = await call(`${app.url}/api/mappings/${SERIAL}/A1`, "PUT", { spoolId: 7 });
 
     assert.equal(status, 404);
     assert.deepEqual(patches, []);

--- a/test/routes.print.test.js
+++ b/test/routes.print.test.js
@@ -66,10 +66,10 @@ test("every consumption entry carries the slot it will be consumed from", async 
     const [f0, f1, f2, f3] = fixtureFilaments();
     printer.currentMapping = null;
     printer.spoolData = [
-        loadedSlot("A0", { id: 101, idx: f0.idx, type: "PLA", color: f0.color }),
-        loadedSlot("A1", { id: 102, idx: f1.idx, type: "PLA", color: f1.color }),
-        loadedSlot("A2", { id: 103, idx: f2.idx, type: "PLA", color: f2.color }),
-        loadedSlot("A3", { id: 104, idx: f3.idx, type: "PLA", color: f3.color }),
+        loadedSlot("A1", { id: 101, idx: f0.idx, type: "PLA", color: f0.color }),
+        loadedSlot("A2", { id: 102, idx: f1.idx, type: "PLA", color: f1.color }),
+        loadedSlot("A3", { id: 103, idx: f2.idx, type: "PLA", color: f2.color }),
+        loadedSlot("A4", { id: 104, idx: f3.idx, type: "PLA", color: f3.color }),
     ];
 
     const { status, body } = await call(`${app.url}/api/print/${SERIAL}`);
@@ -77,37 +77,37 @@ test("every consumption entry carries the slot it will be consumed from", async 
     assert.equal(status, 200);
     const entries = Object.values(body.fullConsumption);
     assert.equal(entries.length, 4);
-    assert.deepEqual(entries.map(e => e.matchedAmsId), ["A0", "A1", "A2", "A3"]);
+    assert.deepEqual(entries.map(e => e.matchedAmsId), ["A1", "A2", "A3", "A4"]);
 
     // The partial map is annotated as well, or the "printed" figure would land
     // on no row at all.
-    assert.deepEqual(Object.values(body.consumption).map(e => e.matchedAmsId), ["A0", "A1", "A2", "A3"]);
+    assert.deepEqual(Object.values(body.consumption).map(e => e.matchedAmsId), ["A1", "A2", "A3", "A4"]);
 });
 
 test("what the printer reports beats the colours the file was sliced with", async () => {
     const [f0, f1, f2, f3] = fixtureFilaments();
-    // The printer runs filament 0 from A3 and filament 3 from A0, which is the
+    // The printer runs filament 0 from A4 and filament 3 from A1, which is the
     // remap it reports and the sliced colours cannot know about.
     const { decodePrintMapping } = await import("../src/gcode.js");
     printer.currentMapping = decodePrintMapping([0x0003, 0x0001, 0x0002, 0x0000]);
     printer.spoolData = [
-        loadedSlot("A0", { id: 101, idx: f0.idx, type: "PLA", color: f0.color }),
-        loadedSlot("A1", { id: 102, idx: f1.idx, type: "PLA", color: f1.color }),
-        loadedSlot("A2", { id: 103, idx: f2.idx, type: "PLA", color: f2.color }),
-        loadedSlot("A3", { id: 104, idx: f3.idx, type: "PLA", color: f3.color }),
+        loadedSlot("A1", { id: 101, idx: f0.idx, type: "PLA", color: f0.color }),
+        loadedSlot("A2", { id: 102, idx: f1.idx, type: "PLA", color: f1.color }),
+        loadedSlot("A3", { id: 103, idx: f2.idx, type: "PLA", color: f2.color }),
+        loadedSlot("A4", { id: 104, idx: f3.idx, type: "PLA", color: f3.color }),
     ];
 
     const { body } = await call(`${app.url}/api/print/${SERIAL}`);
     const entries = Object.values(body.fullConsumption);
 
-    assert.deepEqual(entries.map(e => e.matchedAmsId), ["A3", "A1", "A2", "A0"]);
+    assert.deepEqual(entries.map(e => e.matchedAmsId), ["A4", "A2", "A3", "A1"]);
     // The slot the slice named stays next to it, because the two differ exactly
     // where the printer remapped the job and both are worth reading.
-    assert.deepEqual(entries.map(e => e.amsId), ["A3", "A1", "A2", "A0"]);
+    assert.deepEqual(entries.map(e => e.amsId), ["A4", "A2", "A3", "A1"]);
     assert.ok(entries.every(e => e.amsIdFromPrinter));
 
     // No slot carries two filaments here, which is what the claim on a reported
-    // slot is for: the colours of A0 and A3 both appear in the file.
+    // slot is for: the colours of A1 and A4 both appear in the file.
     const claimed = entries.map(e => e.matchedAmsId);
     assert.equal(new Set(claimed).size, claimed.length);
 });
@@ -117,7 +117,7 @@ test("a filament nothing loaded can serve stays unplaced", async () => {
     // shares its profile with the loaded slot, see the test below.
     const [f0] = fixtureFilaments();
     printer.currentMapping = null;
-    printer.spoolData = [loadedSlot("A0", { id: 101, idx: f0.idx, type: "PLA", color: f0.color })];
+    printer.spoolData = [loadedSlot("A1", { id: 101, idx: f0.idx, type: "PLA", color: f0.color })];
 
     const { body } = await call(`${app.url}/api/print/${SERIAL}`);
     const unplaced = Object.values(body.fullConsumption).filter(e => e.matchedAmsId === null);
@@ -133,11 +133,11 @@ test("a slot carries only the filament that is really its own", async () => {
     // spool that never printed it, and the dashboard would show it there.
     const [f0] = fixtureFilaments();
     printer.currentMapping = null;
-    printer.spoolData = [loadedSlot("A0", { id: 101, idx: f0.idx, type: "PLA", color: f0.color })];
+    printer.spoolData = [loadedSlot("A1", { id: 101, idx: f0.idx, type: "PLA", color: f0.color })];
 
     const { body } = await call(`${app.url}/api/print/${SERIAL}`);
     const entries = Object.values(body.fullConsumption);
-    const onA0 = entries.filter(e => e.matchedAmsId === "A0");
+    const onA0 = entries.filter(e => e.matchedAmsId === "A1");
 
     assert.equal(onA0.length, 1);
     assert.equal(onA0[0].color.replace("#", "").toUpperCase(), f0.color.toUpperCase());
@@ -149,7 +149,7 @@ test("an empty slot is not offered to the match", async () => {
     printer.currentMapping = null;
     // An empty slot whose last reported payload still looks like the filament.
     // Nothing may be booked or shown on it, so it must not become a candidate.
-    printer.spoolData = [loadedSlot("A0", { id: 101, idx: f0.idx, type: "PLA", color: f0.color, state: "Empty" })];
+    printer.spoolData = [loadedSlot("A1", { id: 101, idx: f0.idx, type: "PLA", color: f0.color, state: "Empty" })];
 
     const { body } = await call(`${app.url}/api/print/${SERIAL}`);
 

--- a/test/routes.spooledit.test.js
+++ b/test/routes.spooledit.test.js
@@ -27,10 +27,10 @@ before(async () => {
     printer = printers.find(p => p.id === SERIAL);
     printer.currentGcodeState = "IDLE";
     printer.spoolData = [{
-        amsId: "A0",
+        amsId: "A1",
         slotState: "Loaded (Bambu Lab)",
         existingSpool: { id: SPOOL_ID, remaining_weight: 500, filament: { name: "spool 42" } },
-        slot: { tray_uuid: "uuid-A0" },
+        slot: { tray_uuid: "uuid-A1" },
     }];
 });
 

--- a/test/uispool.test.js
+++ b/test/uispool.test.js
@@ -19,7 +19,7 @@ after(async () => { await app.close(); });
 /** A UI spool as processSlot() builds it for an identified Bambu Lab spool. */
 function uiSpool(overrides = {}) {
     return {
-        amsId: "A0",
+        amsId: "A1",
         slot: {
             id: 0,
             tray_uuid: "ABCD",
@@ -98,7 +98,7 @@ test("the readable name and the consumption key are derived once, on the server"
 test("a missing assignment reads as false rather than absent", () => {
     // The UI branches on these, so an undefined would silently render as "not
     // tracked" wherever a builder forgot to set it
-    const client = toClientSpool({ amsId: "A1", slot: {}, slotState: "Empty" });
+    const client = toClientSpool({ amsId: "A2", slot: {}, slotState: "Empty" });
 
     assert.equal(client.connectedViaTag, false);
     assert.equal(client.connectedViaMapping, false);
@@ -111,7 +111,7 @@ test("the N/A placeholder does not reach a client", () => {
     // backend marker, and a client that receives it renders it, which is how an
     // emptied slot ended up labelled "N/A" with a `#N/A` colour swatch.
     const client = toClientSpool({
-        amsId: "A0",
+        amsId: "A1",
         slotState: "Empty",
         slot: { id: 0, state: 10, remain: 0, tray_color: "N/A", tray_sub_brands: "N/A", tray_weight: 0, tray_uuid: "N/A" },
     });
@@ -128,7 +128,7 @@ test("a 3rd party slot keeps what the printer does know", () => {
     // Material and colour set on the AMS are real values and have to survive,
     // even though the same record carries placeholders next to them.
     const client = toClientSpool({
-        amsId: "B0",
+        amsId: "B1",
         slotState: "Loaded (3rd party)",
         slot: { id: 0, state: 11, tray_info_idx: "GFL99", tray_type: "PLA", tray_sub_brands: "N/A", tray_color: "0ACC38FF", tray_weight: "0", tray_uuid: "N/A", remain: 0 },
     });
@@ -219,7 +219,7 @@ test("a slot without cols still reports the one colour the printer sends", () =>
 
 test("an empty slot reports no colours at all", () => {
     const client = toClientSpool({
-        amsId: "A1",
+        amsId: "A2",
         slotState: "Empty",
         slot: { id: 1, state: 10, remain: 0, tray_color: "N/A", tray_sub_brands: "N/A", tray_weight: 0, tray_uuid: "N/A" },
     });

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -1,0 +1,30 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { convertAMSandSlot, EXTERNAL_SLOT } from "../src/utils.js";
+
+test("a unit's slots are labelled the way the printer counts them", () => {
+    // MQTT counts a unit's slots from 0, the printer's display and Bambu Studio
+    // from 1. The label is read next to that hardware, so it says the same.
+    assert.deepEqual([0, 1, 2, 3].map(slot => convertAMSandSlot(0, slot)), ["A1", "A2", "A3", "A4"]);
+    assert.equal(convertAMSandSlot(3, 3), "D4");
+    // The ids arrive as strings in some reports and as numbers in others
+    assert.equal(convertAMSandSlot("1", "0"), "B1");
+});
+
+test("a unit without a slot is the unit's own label", () => {
+    // What the AMS environment readings are keyed by: the unit, not a slot in it
+    assert.equal(convertAMSandSlot(0, null), "A");
+    assert.equal(convertAMSandSlot(1, null), "B");
+});
+
+test("the single slot units carry no slot number", () => {
+    assert.equal(convertAMSandSlot(128, 0), "HT-A");
+    assert.equal(convertAMSandSlot(135, 0), "HT-H");
+    assert.equal(convertAMSandSlot(255, 0), EXTERNAL_SLOT);
+});
+
+test("a unit outside the known ranges is marked as unaddressable", () => {
+    assert.equal(convertAMSandSlot(4, 0), "Z");
+    assert.equal(convertAMSandSlot(127, 0), "Z");
+});


### PR DESCRIPTION
The first slot of the first unit is `A1` and the last one of a fourth unit is `D4`, so a slot label says what the printer's display, its touchscreen and Bambu Studio say. Before this, the second slot of the AMS was `A1` on one screen and `A2` on the other.

The label is a stored key and a written value, not only a caption, so the change reaches further than the Web UI.

## What changed

* `convertAMSandSlot()` adds one to the slot id the MQTT payload carries. A unit without a slot ("A"), the AMS HT units and the external holder are unaffected.
* `printers/mappings.json` is renumbered on the first start. The file gains a `schemaVersion` and holds its assignments under `printers`, because the labels alone cannot say which numbering they were written in: an old `A1` is the second slot and a new one is the first. A flat file is version 0, is renumbered once and is written back. `HT-A` to `HT-H` and `External` carry no number and are passed through, as is any key this version does not recognise.
* `orderedAmsSlots()` counts a unit's slots from 1, which is the path deciding which sliced filament comes out of which slot.
* The Spoolman location of a spool follows on the next reading of the AMS, since `claimSlotLocation()` rewrites a location that no longer matches. A location set by hand is still left alone.
* The diagnostics bundle masks the serials inside the mapping file's `printers` instead of the keys of the file itself, which the wrapper would otherwise have renamed.
* Doc comments, `docs/how-it-works.md`, `docs/troubleshooting.md`, `src/AGENTS.md` and the test server scenario carry the new labels.

## Breaking

* A caller of the API sees the new labels in `amsId`. The Home Assistant integration is the one to check first.
* An older build does not read the wrapper and would start with an empty mapping file, so a downgrade loses the manual assignments.

## Verified

Against the real P2S with its AMS units and the external holder, in a container run with `MODE: manual` and `SET_LOCATION: false` on a copy of `printers/`, so nothing was written to Spoolman:

* the slots read `A1`, `A2`, `A4`, `B1`, `B3`, `B4` and `External`, in the log and in the API
* the existing `mappings.json` was renumbered on the first start, `A2` to `A3` and `A1` to `A2`, each staying with the physical slot it was made for
* the assignment whose slot now holds a different filament was dropped by the fingerprint check, exactly as it would have been before the renumbering

Against the mock printer of `scripts/test-server`, which covers every addressable position in one run: all 24 slots plus `HT-A` to `HT-H` and the holder, a flat mapping file renumbered on start, and the locations rewritten to the new labels.

The G-code booking path holds by unit test only. It needs a sliced file and a running print, which is the hardware gap tracked in `OPEN.md`.

`npm test`: 390 tests, all passing, including the new `test/utils.test.js` and the migration and parsing cases in `test/mappings.test.js`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)