### PR TITLE
docs: the README says that the external spool holder exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 -----------------------------------------------------------------------------------------------
 Unreleased
+   - Documentation:
+      - The README says that the external spool holder exists. It has been a slot of its own since 1.3.0, named External, and nothing on the front page mentioned it: not what the service does, not the supported hardware, not the feature list. It is assigned by hand like any 3rd party spool and is not read in legacy mode, which the hardware section now says
+      - "What changed in 1.3.0" carries the two changes an existing installation can trip over, the password and the API key, and the slot renumbering, next to the three that were already there
+      - The feature list names the humidity, temperature and drying readings per AMS unit, and says the Web UI works on a phone
+      - "How it works" opens with what the printer reports about its slots rather than with the AMS report, since the holder is reported outside the AMS block altogether
    - Fixes:
       - The anonymised diagnostics bundle masks the RFID tag of a spool, in the ordinary log lines and in the debug dumps. Everything after the first four characters is replaced, the way a serial number keeps five: four is enough to see that two lines are about the same spool and far too few to recognise the spool by
          - A tag on its own is a piece of filament rather than a person, which is why it used to be handed out whole. A bundle carries every tag of a shelf at once though, next to the printer they sit in, and read across several reports that says what somebody owns and prints with

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Based on the idea of a script from [Diogo Resende](https://github.com/dresende),
 
 Every Bambu Lab printer reports what its AMS holds, and every sliced print says how much of each filament it needs. This service listens to both and keeps [Spoolman](https://github.com/Donkie/Spoolman) in step with them: it recognises the spools in your AMS, links them to the spools in your inventory, and books what a print actually used onto the right one when the job is done, without you touching Spoolman.
 
-An original Bambu Lab spool is recognised by its RFID tag and linked on its own; a 3rd party spool is linked to a Spoolman spool once, by hand in the Web UI, and is tracked from then on like any other. Everything runs in one Docker container on your own network, over MQTT and FTPS to the printer. Nothing goes through the Bambu cloud.
+An original Bambu Lab spool is recognised by its RFID tag and linked on its own; a 3rd party spool is linked to a Spoolman spool once, by hand in the Web UI, and is tracked from then on like any other. The external spool holder is one more slot next to the AMS units and is treated the same way. Everything runs in one Docker container on your own network, over MQTT and FTPS to the printer. Nothing goes through the Bambu cloud.
 
 ![Dashboard](docs/images/dashboard-dark.png)
 
@@ -45,6 +45,8 @@ An original Bambu Lab spool is recognised by its RFID tag and linked on its own;
 - **G-code tracking is the new default.** Filament consumption is read from the sliced file of the print instead of the AMS RFID remain percentage, so 3rd party spools without a tag are covered as well. The previous behaviour lives on as [Legacy mode](docs/legacy-mode.md).
 - **Everything is configured in the Web UI now.** The [settings page](docs/settings.md) holds every setting and the printer list.
 - **Environment variables and hand-written `printers.json` are deprecated.** They keep working, see [Deprecated configuration](docs/deprecated-configuration.md).
+- **The Web UI can ask for a password, and the API needs a key.** Both are set under **Network access** on the [settings page](docs/settings.md). A script or an integration that called the API without a key needs one now.
+- **Slots are numbered the way the printer numbers them.** The first slot of the first unit is `A1`, so every slot label moved up by one, in the Web UI, in the logs, in the API and in the Spoolman location of a spool.
 
 ## Attention
 
@@ -71,22 +73,26 @@ Automatic creating and merging of spools and filaments in Spoolman relies on the
 
 Up to 12 AMS on one printer: max. 4 AMS Standard / 2 Pro plus 8 AMS HT.
 
+The external spool holder counts as one more slot, named `External`, on a printer that reports it. It carries no RFID chip, so it is assigned to a Spoolman spool by hand like any 3rd party spool, and it is not read in [legacy mode](docs/legacy-mode.md), where the weight comes from the chip.
+
 x86-64, arm64 and arm/v7 are built; the [installation](docs/installation.md#supported-architectures) says which device falls under which.
 
 ## Features
 
-- Real-time AMS status for every connected AMS, on any number of printers
+- Real-time status of every connected AMS and of the external spool holder, on any number of printers
+- The humidity, the temperature and a running drying cycle per AMS unit, as far as the unit reports them
 - Consumption tracked from the sliced G-code, so 3rd party spools are covered too
 - Automatic merging and creating of spools and filaments in Spoolman, or manually per click
-- Manual assignment of a Spoolman spool to an AMS slot for spools the printer cannot identify, checked against the material the printer reports
+- Manual assignment of a Spoolman spool to a slot for spools the printer cannot identify, checked against the material the printer reports
 - A detail dialog per slot: everything Spoolman holds about the spool and its filament, next to what the printer reports, with the remaining weight, lot number and comment editable in place
 - New filaments filled in from the SpoolmanDB catalogue, multi colour spools included
-- Web UI with print dashboard, printer management, settings and log viewer, no container restart needed
+- Web UI with print dashboard, printer management, settings and log viewer, no container restart needed, and usable on a phone
+- An optional password in front of the Web UI, and named API keys for callers that have no browser
 - Lightweight Docker container, ready for x86-64, arm64 and arm/v7
 
 ## How it works
 
-The printers publish their state via MQTT, this service listens and talks to Spoolman through its API. From what an AMS reports it merges a detected spool into a matching Spoolman spool, creates the spool when only the filament exists, or imports the filament from the SpoolmanDB and creates both, automatically or per click in `manual` mode.
+The printers publish their state via MQTT, this service listens and talks to Spoolman through its API. From what a printer reports about its slots it merges a detected spool into a matching Spoolman spool, creates the spool when only the filament exists, or imports the filament from the SpoolmanDB and creates both, automatically or per click in `manual` mode.
 
 While a print runs, the sliced `.gcode.3mf` is fetched from the printer via FTPS and the grams per filament are read from it. When the job reaches a final state, that amount is booked onto the linked spool; a cancelled print is booked proportionally to the layers printed. A slot that is linked to nothing is named in the log and skipped, so a missing link is visible rather than silently untracked.
 

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -4,9 +4,9 @@
 
 The printers publish their state via MQTT, this service listens and talks to Spoolman through its API.
 
-From the AMS report it can:
+From what the printer reports about its slots, the AMS units and the external spool holder alike, it can:
 
-- **Merge spools**: a spool in the AMS whose material, colour and remaining weight match a spool in Spoolman that carries no tag is merged with it. The serial number of the AMS spool is written into the spool's extra field `tag`, which links the two from then on.
+- **Merge spools**: a spool in a slot whose material, colour and remaining weight match a spool in Spoolman that carries no tag is merged with it. The serial number of the detected spool is written into the spool's extra field `tag`, which links the two from then on.
 - **Create spools**: a detected spool with a matching registered filament in Spoolman, but no spool, gets one created, tag included.
 - **Create filaments and spools**: with no matching filament either, the filament is imported from the SpoolmanDB, registered, and the spool created on top of it.
 
@@ -18,7 +18,7 @@ Because the numbers come from the slicer and not from the RFID chip, this works 
 
 The link is dropped automatically as soon as a different filament is detected in that slot. It also resolves the rare case of two loaded spools that are identical in material and colour, which the RFID tag alone cannot tell apart.
 
-Two things follow from booking per print rather than per AMS report:
+Two things follow from booking per print rather than per report:
 
 - **A slot needs a link before its consumption can be booked**, either the tag of a Bambu Lab spool or a manual assignment. A filament the print uses from a slot that has neither is named in the log and skipped, so it is visible which spool is missing its link rather than silently going untracked.
 - **Nothing is written to Spoolman while a print runs.** The whole amount is booked when the job reaches its final state, so a spool in Spoolman stands still during the print and then jumps. The Web UI shows the progress in the meantime, per spool as "on spool / needed / rest".


### PR DESCRIPTION
> Stacked on #120, which is stacked on #119. Merge in that order and each base folds into `main` on its own.

A pass over the README for what 1.3.0 changed and the front page never picked up.

## The external spool holder

It has been a slot of its own since 1.3.0, named `External`, and nothing on the front page mentioned it: not "What it does", not the supported hardware, not the feature list. Somebody with a spool on the holder had no way to tell from the README whether it is covered.

It is now named in all three, with the two things that actually matter about it: it carries no chip, so it is assigned to a Spoolman spool by hand like any 3rd party spool, and it is not read in legacy mode, where the weight comes from the chip.

## What changed in 1.3.0

The section listed three changes and left out the two an existing installation can trip over, both of them labelled `breaking` when they landed:

- the Web UI password and the API key, where a script or an integration that called the API without a key needs one now
- the slot renumbering, where every label moved up by one

## Features

- The humidity, the temperature and a running drying cycle per AMS unit, as far as the unit reports them.
- The Web UI works on a phone.
- The optional password and the named API keys, which only appeared in the warning at the bottom of the page.
- "Manual assignment of a Spoolman spool to an AMS slot" became "to a slot", matching #119.

## How it works

The opening line described the AMS report as the source. The external holder is reported outside the AMS block altogether, so both the README section and `docs/how-it-works.md` now open with what the printer reports about its slots. The merge bullet on that page follows.

## Testing

Documentation only, no code touched. `npm test` was run anyway, 395 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)