### PR TITLE
chore: bump the version to 1.3.0-dev.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 -----------------------------------------------------------------------------------------------
-Unreleased
+Version 1.3.0-dev.10
    - Documentation:
       - The README says that the external spool holder exists. It has been a slot of its own since 1.3.0, named External, and nothing on the front page mentioned it: not what the service does, not the supported hardware, not the feature list. It is assigned by hand like any 3rd party spool and is not read in legacy mode, which the hardware section now says
       - "What changed in 1.3.0" carries the two changes an existing installation can trip over, the password and the API key, and the slot renumbering, next to the three that were already there

--- a/OPEN.md
+++ b/OPEN.md
@@ -162,7 +162,7 @@ None of this involved real hardware, so it says nothing about the items above.
 ## Before the next official release
 
 The version deliberately stays on a `-dev` prerelease for now, currently
-`1.3.0-dev.9`.
+`1.3.0-dev.10`.
 
 - [ ] Set the version to `1.3.0` in **both** `package.json` and `src/config.js`.
   The publish workflow compares the tag against `package.json` and aborts on a
@@ -175,7 +175,7 @@ The version deliberately stays on a `-dev` prerelease for now, currently
   images read to see what changed between two builds. This has to happen before
   the tag is pushed: the release body is the `CHANGELOG.md` section for exactly
   that version, so without a `Version 1.3.0` section the release says it has no
-  notes. The draft covers up to `dev.7` and carries two open questions of its
+  notes. The draft covers up to `dev.10` and carries two open questions of its
   own, on the deprecation of the environment variables and on a test count that
   goes stale.
 
@@ -184,7 +184,7 @@ Tag behaviour, after the hardening in `c053561`:
 | Tag | Images | `:latest` | GitHub release |
 |---|---|---|---|
 | `v1.3.0` | `:1.3.0` and `:latest` | moved | release, marked Latest |
-| `v1.3.0-dev`, `v1.3.0-dev.2`, `v1.3.0-dev.3`, `v1.3.0-dev.4`, `v1.3.0-dev.5`, `v1.3.0-dev.6`, `v1.3.0-dev.7`, `v1.3.0-dev.8`, `v1.3.0-dev.9` | `:<version>` and `:dev` | untouched | pre-release |
+| `v1.3.0-dev`, `v1.3.0-dev.2`, `v1.3.0-dev.3`, `v1.3.0-dev.4`, `v1.3.0-dev.5`, `v1.3.0-dev.6`, `v1.3.0-dev.7`, `v1.3.0-dev.8`, `v1.3.0-dev.9`, `v1.3.0-dev.10` | `:<version>` and `:dev` | untouched | pre-release |
 | `v1.3.0-rc1` and other suffixes | `:<version>` only | untouched | pre-release |
 
 One `case` decides all four columns, so the image tags and the release cannot

--- a/docs/changelog-1.3.0-draft.md
+++ b/docs/changelog-1.3.0-draft.md
@@ -6,7 +6,7 @@ between two builds. This file is the consolidated release block, written into
 CHANGELOG.md in place of those dev blocks when the release build is cut, not
 before.
 
-Every dev build after dev.9 has to be folded in here as well, or regenerate the
+Every dev build after dev.10 has to be folded in here as well, or regenerate the
 whole block from the dev blocks at release time.
 
 ## Draft
@@ -41,9 +41,14 @@ Version 1.3.0
       - The assignment picker suggests the spools that fit the slot first, by material family and colour, and warns when slot and spool disagree on the material
       - Settings page for everything that used to be an environment variable, plus the printer list, applied without a restart
       - Service card with version, platform, uptime, tracking mode and Spoolman connection, plus update check, reconnect all printers, pause monitoring and a diagnostics download
+      - The diagnostics download is one archive with everything a bug report needs: version and platform, the settings with the origin of each value, the printer list, the assignments and the logs including their rotated history. It is offered anonymised, which is the default
+         - Anonymised replaces the last octet of every IP address, everything after the first five characters of a serial number, everything after the first four characters of the RFID tag of a spool, the Spoolman host name, and it shortens the data and log paths. Enough of a serial or a tag survives to see that two lines are about the same printer or the same spool, and too little to identify either
+         - What a slot reports when it has no chip, "N/A" or an all zero uuid, is not a tag and stays as it is: it is the answer to half the questions a report about a 3rd party spool is asking
+         - The Web UI password, the API keys and the printer access codes are in no variant of the archive, anonymised or not
       - Clicking the filament name of a slot opens a dialog with everything the printer and Spoolman hold about it; remaining weight, lot number and comment can be corrected there
       - A spool that runs empty is archived in Spoolman on its own, off by default, with a threshold in grams
       - The external spool holder is shown as a slot of its own and can be assigned
+         - It is a slot and not an AMS, so nothing is called an AMS slot any more where the holder can be meant: the two settings that carry the update interval and the location, the dashboard, and the dialogs of a slot. Two log lines change with it, "No new AMS Data or changes in Spoolman found ..." and "Spool successfully created for AMS Slot => ...", both of which now say "slot". A script that greps the log for either has to be adjusted
       - Multi colour filaments are read, drawn and created with all of their colours
       - The Spoolman location of a spool follows the AMS slot it sits in, and is cleared when it leaves
       - Log files are rotated instead of growing forever, and the log view and download read across the rotated history
@@ -88,6 +93,6 @@ Version 1.3.0
       - extractAmsEnvironment() in src/ams.js is the one reading of the per-unit environment fields, covered against the four unit shapes that have been observed
       - New test server under scripts/test-server: a mock printer and a mock Spoolman, started with one command
       - The test suite runs on node:test and covers public/ for the first time
-      - The release notes of every version carry the merged pull requests grouped by the label they were given, configured in .github/release.yml, with the breaking ones first
+      - The release notes of every version carry the merged pull requests grouped by the label they were given, configured in .github/release.yml, with the breaking ones first. The release body opens with that list and ends with the changelog section, rather than burying the list under sixty lines of prose
 
 -----------------------------------------------------------------------------------------------

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bambulab-ams-spoolman-filamentstatus",
-  "version": "1.3.0-dev.9",
+  "version": "1.3.0-dev.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bambulab-ams-spoolman-filamentstatus",
-      "version": "1.3.0-dev.9",
+      "version": "1.3.0-dev.10",
       "license": "ISC",
       "dependencies": {
         "adm-zip": "^0.6.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "mqtt": "^5.15.2"
   },
   "name": "bambulab-ams-spoolman-filamentstatus",
-  "version": "1.3.0-dev.9",
+  "version": "1.3.0-dev.10",
   "main": "app.js",
   "type": "module",
   "engines": {

--- a/src/config.js
+++ b/src/config.js
@@ -32,7 +32,7 @@ export const apiKeysPath = path.join(dataDir, "apikeys.json");
 // brings the service back on its own or depends on the container policy.
 export const supervised = process.env.SUPERVISED === "1";
 
-export const version = "1.3.0-dev.9";
+export const version = "1.3.0-dev.10";
 export const PORT = 4000;
 export const RECONNECT_INTERVAL = 60000;
 


### PR DESCRIPTION
Cuts the next dev prerelease.

## Version

`package.json`, `package-lock.json` and `src/config.js` are bumped together. The publish workflow compares the tag against `package.json` and aborts on a mismatch, and `src/config.js` is what the Web UI and the diagnostics bundle report, so a bump in only one of them either fails the build or ships an image that lies about its version.

## Changelog

The section that was called `Unreleased` becomes the section for this prerelease, because everything in it ships with the tag and the release body is that section. It carries #119, #120, #121 and the `qs` security bump in #123.

`OPEN.md` lists the new tag next to the other prereleases and no longer claims the draft stops at `dev.7`.

## Release notes draft

`docs/changelog-1.3.0-draft.md` folds in dev.10, judged against 1.2.1 the way the rest of the draft is:

- **The diagnostics download gains a bullet of its own**, with what the anonymised variant masks, the RFID tag included. It is a 1.3.0 feature the draft mentioned only in passing, and masking the tag is a property of that feature rather than a fix anybody upgrading from 1.2.1 ever saw broken.
- **The naming goes onto the external spool holder**, which is the reason for it, together with the two log lines a 1.2.1 installation really does see change: `No new AMS Data or changes in Spoolman found ...` and `Spool successfully created for AMS Slot => ...`.
- **The release notes line under Development** says that the body now opens with the pull request list and ends with the changelog section.

Left out are the settings labels. `UPDATE_INTERVAL` and `SET_LOCATION` were environment variables in 1.2.1 with no label to rename, so that rename exists only inside the 1.3.0 dev cycle and no upgrading installation ever saw the old wording.

## Testing

`npm test`, 395 passing. `src/config.js` reports `1.3.0-dev.10`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)