### PR TITLE
fix: clear the location of a slot that vanishes from the report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Version 1.3.0-dev.10
       - The feature list names the humidity, temperature and drying readings per AMS unit, and says the Web UI works on a phone
       - "How it works" opens with what the printer reports about its slots rather than with the AMS report, since the holder is reported outside the AMS block altogether
    - Fixes:
+      - Taking the spool off the external spool holder clears its location in Spoolman. The holder is only reported as a slot while it carries something, so an emptied holder does not appear in the report at all, and the code that clears a location only ran for slots the report still contained. The spool kept "<printer> - External" long after it had been taken off, and nothing would ever have cleared it
+         - The same applies to an AMS unit that stops being reported, for instance an unplugged one: its slots are now released as well
+         - A location that does not name this printer is still left alone, so anything set by hand survives
       - The anonymised diagnostics bundle masks the RFID tag of a spool, in the ordinary log lines and in the debug dumps. Everything after the first four characters is replaced, the way a serial number keeps five: four is enough to see that two lines are about the same spool and far too few to recognise the spool by
          - A tag on its own is a piece of filament rather than a person, which is why it used to be handed out whole. A bundle carries every tag of a shelf at once though, next to the printer they sit in, and read across several reports that says what somebody owns and prints with
          - What a slot reports when it has no tag, "N/A" or an all zero uuid, is not a tag and stays as it is: it is the answer to half the questions a report about a 3rd party spool is asking

--- a/src/mqtt.js
+++ b/src/mqtt.js
@@ -508,6 +508,8 @@ async function handleMqttMessage(printer, topic, message) {
                                 }
                             }
 
+                            releaseVanishedSlots(locationSync, prevByAmsId, printer.spoolData, spools);
+
                             await locationSync.flush();
 
                             state.lastSpoolData = spools;
@@ -578,6 +580,33 @@ function releasePreviousSpool(locationSync, amsId, prevByAmsId, spools) {
 
     const current = (spools || []).find(s => s.id === prevSpoolId);
     locationSync.release(current ?? prevByAmsId[amsId].existingSpool);
+}
+
+/**
+ * Releases the spools of slots the report no longer contains at all.
+ *
+ * `releasePreviousSpool()` only runs from inside `processSlot()`, so it can
+ * only clear a location when the slot it belonged to is still in the report. A
+ * slot can also disappear outright: taking the spool off the external holder
+ * makes `externalSpoolUnits()` emit no unit, and an unplugged AMS drops out of
+ * `print.ams.ams` the same way. Nothing then walked that slot, nothing released
+ * it, and the spool kept "Printer - External" in Spoolman forever.
+ *
+ * Compared against the slots this update actually built, not against the
+ * report, so a slot that was skipped as invalid counts as gone as well.
+ *
+ * @param {object} locationSync - the collector for this AMS update
+ * @param {object} prevByAmsId - the previous UI spools, keyed by slot label
+ * @param {object[]} spoolData - the UI spools this update built
+ * @param {object[]} spools - Spoolman spools, as fetched for this AMS update
+ */
+export function releaseVanishedSlots(locationSync, prevByAmsId, spoolData, spools) {
+    const seen = new Set((spoolData || []).map(s => s.amsId));
+
+    for (const amsId of Object.keys(prevByAmsId)) {
+        if (seen.has(amsId)) continue;
+        releasePreviousSpool(locationSync, amsId, prevByAmsId, spools);
+    }
 }
 
 // How many AMS updates a slot may wait for its remain reading before a spool is

--- a/test/mqtt.external.test.js
+++ b/test/mqtt.external.test.js
@@ -1,7 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { externalSpoolUnits } from "../src/mqtt.js";
+import { externalSpoolUnits, releaseVanishedSlots } from "../src/mqtt.js";
 import { processData, slotIsOccupied } from "../src/ams.js";
 import { convertAMSandSlot, EXTERNAL_SLOT } from "../src/utils.js";
 
@@ -96,4 +96,43 @@ test("a holder is one filament, never part of a four slot unit", () => {
     // units and where exactly is not pinned down by any observed file.
     assert.equal(EXTERNAL_SLOT.startsWith("HT-"), false);
     assert.equal("ABCD".includes(EXTERNAL_SLOT[0]), false);
+});
+
+// A slot that disappears from the report has no processSlot() run of its own,
+// so releasePreviousSpool() never fires for it. Taking the spool off the holder
+// is exactly that case: externalSpoolUnits() emits no unit any more.
+function recordingSync() {
+    const released = [];
+    return { released, release(spool) { released.push(spool.id); } };
+}
+
+test("a slot that is gone from the report releases its spool", () => {
+    const sync = recordingSync();
+    const prevByAmsId = {
+        A1: { amsId: "A1", existingSpool: { id: 1 } },
+        [EXTERNAL_SLOT]: { amsId: EXTERNAL_SLOT, existingSpool: { id: 7 } },
+    };
+    // Only A1 was rebuilt this update, the holder yielded no unit at all
+    const spoolData = [{ amsId: "A1" }];
+
+    releaseVanishedSlots(sync, prevByAmsId, spoolData, [{ id: 1 }, { id: 7 }]);
+
+    assert.deepEqual(sync.released, [7]);
+});
+
+test("a slot still in the report is left to processSlot", () => {
+    const sync = recordingSync();
+    const prevByAmsId = { [EXTERNAL_SLOT]: { amsId: EXTERNAL_SLOT, existingSpool: { id: 7 } } };
+
+    releaseVanishedSlots(sync, prevByAmsId, [{ amsId: EXTERNAL_SLOT }], [{ id: 7 }]);
+
+    assert.deepEqual(sync.released, []);
+});
+
+test("a vanished slot that held no spool releases nothing", () => {
+    const sync = recordingSync();
+
+    releaseVanishedSlots(sync, { [EXTERNAL_SLOT]: { amsId: EXTERNAL_SLOT, existingSpool: null } }, [], []);
+
+    assert.deepEqual(sync.released, []);
 });


### PR DESCRIPTION
Taking the spool off the external spool holder left its Spoolman location on the spool forever.

## What was wrong

The holder is only reported as a slot while it carries something: with nothing on it, `externalSpoolUnits()` filters the record out and emits no unit at all. Location clearing runs from `releasePreviousSpool()` inside `processSlot()`, which only ever sees slots the report still contains, so nothing walked the holder and nothing released it. The spool kept `<printer> - External` and no later update would have cleared it.

An AMS unit that stops being reported, an unplugged one for instance, dropped out the same way.

## The fix

`releaseVanishedSlots()` compares the previous slots against the ones the update actually built and hands the difference to the location sync, right before it flushes. A slot that is gone releases its spool alongside the ones the report still contains.

It compares against the built slots rather than against the report, so a slot skipped as invalid counts as gone as well. `ownsLocation()` is untouched: a location that does not name this printer still survives.

## Verified on hardware

Against a real P2S and a throwaway Spoolman, with `SET_LOCATION` on:

```
Set location "Bambu Lab Printer - External" for Spool-ID 19
Cleared location for Spool-ID 19
```

The spool was assigned to the holder by hand, then taken off the holder physically. Spoolman shows `location: ""` afterwards. The six AMS slots kept their locations, and a spool carrying a location written under a different printer name was left alone.

The vanished AMS unit is covered by unit test only, not physically reproduced.

## Tests

Three cases in `test/mqtt.external.test.js`: a slot gone from the report releases its spool, a slot still in the report is left to `processSlot()`, and a vanished slot that held no spool releases nothing. Full suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)