### PR TITLE
chore: bump the version to 1.3.0-dev.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
 -----------------------------------------------------------------------------------------------
+Version 1.3.0-dev.11
+   - Fixes:
+      - Taking the spool off the external spool holder clears its location in Spoolman. The holder is only reported as a slot while it carries something, so an emptied holder does not appear in the report at all, and the code that clears a location only ran for slots the report still contained. The spool kept "<printer> - External" long after it had been taken off, and nothing would ever have cleared it
+         - The same applies to an AMS unit that stops being reported, for instance an unplugged one: its slots are now released as well
+         - A location that does not name this printer is still left alone, so anything set by hand survives
+
+-----------------------------------------------------------------------------------------------
 Version 1.3.0-dev.10
    - Documentation:
       - The README says that the external spool holder exists. It has been a slot of its own since 1.3.0, named External, and nothing on the front page mentioned it: not what the service does, not the supported hardware, not the feature list. It is assigned by hand like any 3rd party spool and is not read in legacy mode, which the hardware section now says
@@ -6,9 +13,6 @@ Version 1.3.0-dev.10
       - The feature list names the humidity, temperature and drying readings per AMS unit, and says the Web UI works on a phone
       - "How it works" opens with what the printer reports about its slots rather than with the AMS report, since the holder is reported outside the AMS block altogether
    - Fixes:
-      - Taking the spool off the external spool holder clears its location in Spoolman. The holder is only reported as a slot while it carries something, so an emptied holder does not appear in the report at all, and the code that clears a location only ran for slots the report still contained. The spool kept "<printer> - External" long after it had been taken off, and nothing would ever have cleared it
-         - The same applies to an AMS unit that stops being reported, for instance an unplugged one: its slots are now released as well
-         - A location that does not name this printer is still left alone, so anything set by hand survives
       - The anonymised diagnostics bundle masks the RFID tag of a spool, in the ordinary log lines and in the debug dumps. Everything after the first four characters is replaced, the way a serial number keeps five: four is enough to see that two lines are about the same spool and far too few to recognise the spool by
          - A tag on its own is a piece of filament rather than a person, which is why it used to be handed out whole. A bundle carries every tag of a shelf at once though, next to the printer they sit in, and read across several reports that says what somebody owns and prints with
          - What a slot reports when it has no tag, "N/A" or an all zero uuid, is not a tag and stays as it is: it is the answer to half the questions a report about a 3rd party spool is asking

--- a/OPEN.md
+++ b/OPEN.md
@@ -162,7 +162,7 @@ None of this involved real hardware, so it says nothing about the items above.
 ## Before the next official release
 
 The version deliberately stays on a `-dev` prerelease for now, currently
-`1.3.0-dev.10`.
+`1.3.0-dev.11`.
 
 - [ ] Set the version to `1.3.0` in **both** `package.json` and `src/config.js`.
   The publish workflow compares the tag against `package.json` and aborts on a
@@ -175,7 +175,7 @@ The version deliberately stays on a `-dev` prerelease for now, currently
   images read to see what changed between two builds. This has to happen before
   the tag is pushed: the release body is the `CHANGELOG.md` section for exactly
   that version, so without a `Version 1.3.0` section the release says it has no
-  notes. The draft covers up to `dev.10` and carries two open questions of its
+  notes. The draft covers up to `dev.11` and carries two open questions of its
   own, on the deprecation of the environment variables and on a test count that
   goes stale.
 
@@ -184,7 +184,7 @@ Tag behaviour, after the hardening in `c053561`:
 | Tag | Images | `:latest` | GitHub release |
 |---|---|---|---|
 | `v1.3.0` | `:1.3.0` and `:latest` | moved | release, marked Latest |
-| `v1.3.0-dev`, `v1.3.0-dev.2`, `v1.3.0-dev.3`, `v1.3.0-dev.4`, `v1.3.0-dev.5`, `v1.3.0-dev.6`, `v1.3.0-dev.7`, `v1.3.0-dev.8`, `v1.3.0-dev.9`, `v1.3.0-dev.10` | `:<version>` and `:dev` | untouched | pre-release |
+| `v1.3.0-dev`, `v1.3.0-dev.2`, `v1.3.0-dev.3`, `v1.3.0-dev.4`, `v1.3.0-dev.5`, `v1.3.0-dev.6`, `v1.3.0-dev.7`, `v1.3.0-dev.8`, `v1.3.0-dev.9`, `v1.3.0-dev.10`, `v1.3.0-dev.11` | `:<version>` and `:dev` | untouched | pre-release |
 | `v1.3.0-rc1` and other suffixes | `:<version>` only | untouched | pre-release |
 
 One `case` decides all four columns, so the image tags and the release cannot

--- a/docs/changelog-1.3.0-draft.md
+++ b/docs/changelog-1.3.0-draft.md
@@ -6,7 +6,7 @@ between two builds. This file is the consolidated release block, written into
 CHANGELOG.md in place of those dev blocks when the release build is cut, not
 before.
 
-Every dev build after dev.10 has to be folded in here as well, or regenerate the
+Every dev build after dev.11 has to be folded in here as well, or regenerate the
 whole block from the dev blocks at release time.
 
 ## Draft
@@ -51,6 +51,7 @@ Version 1.3.0
          - It is a slot and not an AMS, so nothing is called an AMS slot any more where the holder can be meant: the two settings that carry the update interval and the location, the dashboard, and the dialogs of a slot. Two log lines change with it, "No new AMS Data or changes in Spoolman found ..." and "Spool successfully created for AMS Slot => ...", both of which now say "slot". A script that greps the log for either has to be adjusted
       - Multi colour filaments are read, drawn and created with all of their colours
       - The Spoolman location of a spool follows the AMS slot it sits in, and is cleared when it leaves
+         - A slot that stops being reported releases its spool as well, which is what an emptied external spool holder and an unplugged AMS unit look like: the holder is only reported while it carries something. A location that does not name this printer is left alone either way, so anything set by hand in Spoolman survives
       - Log files are rotated instead of growing forever, and the log view and download read across the rotated history
       - Connection test for Spoolman and for a printer, MQTT and FTPS, against the values in the form
       - Each AMS unit says how it is doing above its slot table: relative humidity, the temperature inside it, and the drying cycle while one is running, with its target temperature and the minutes left

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bambulab-ams-spoolman-filamentstatus",
-  "version": "1.3.0-dev.10",
+  "version": "1.3.0-dev.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bambulab-ams-spoolman-filamentstatus",
-      "version": "1.3.0-dev.10",
+      "version": "1.3.0-dev.11",
       "license": "ISC",
       "dependencies": {
         "adm-zip": "^0.6.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "mqtt": "^5.15.2"
   },
   "name": "bambulab-ams-spoolman-filamentstatus",
-  "version": "1.3.0-dev.10",
+  "version": "1.3.0-dev.11",
   "main": "app.js",
   "type": "module",
   "engines": {

--- a/src/config.js
+++ b/src/config.js
@@ -32,7 +32,7 @@ export const apiKeysPath = path.join(dataDir, "apikeys.json");
 // brings the service back on its own or depends on the container policy.
 export const supervised = process.env.SUPERVISED === "1";
 
-export const version = "1.3.0-dev.10";
+export const version = "1.3.0-dev.11";
 export const PORT = 4000;
 export const RECONNECT_INTERVAL = 60000;
 


### PR DESCRIPTION
Bumps `package.json`, `package-lock.json` and `src/config.js` to `1.3.0-dev.11` for the next pre-release.

The location fix of #125 moves out of the `dev.10` section of `CHANGELOG.md` into a `dev.11` section of its own. It was written into `dev.10` while that tag was already published, so the release body of `v1.3.0-dev.10` does not carry it and the changelog claimed it shipped in a build that never had it.

`OPEN.md` lists the new tag next to the other prereleases and says the draft stops at `dev.11`.

`docs/changelog-1.3.0-draft.md` folds the fix in as a sub-bullet of the location feature rather than as a fix of its own, judged against 1.2.1 the way the rest of the draft is: a 1.2.1 installation has no location that follows a slot and no external spool holder, so there is nothing it ever saw broken. What it does need to know is how far the clearing reaches.

Full suite: 398 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)