### PR TITLE
chore: bump the version to 1.3.0-dev.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 -----------------------------------------------------------------------------------------------
-Version 1.3.0-dev.11
+Version 1.3.0-dev.12
    - Features:
       - A finished print leaves a summary behind. "consumption booked" is a button now, and it opens what the print actually did: the result, when it started and ended, how long it took, how many layers, and one row per filament with the slot it ran from, the grams and the spool they were booked onto
          - The table is every filament of the sliced file and what became of it, which it says above itself, so a line without a booking reads as a filament of the plate rather than as something the service mislaid
@@ -27,6 +27,10 @@ Version 1.3.0-dev.11
       - The layer counter stops running past the end of the print. A 26 layer plate showed "Layer 27 / 26" and 104% on its last layer
          - The two numbers do not count the same way: the sliced file reports the highest layer index, 25 for that plate, while the printer reports the layer count once it has finished, 26. One was added to both, so the last layer of every print overshot
          - The convention had never been written down, which is how it broke. It lives in humanLayers() in shared.js now, next to the note that the server's consumption maths rests on the same 0-based reading of the printer's layer number
+
+-----------------------------------------------------------------------------------------------
+Version 1.3.0-dev.11
+   - Fixes:
       - Taking the spool off the external spool holder clears its location in Spoolman. The holder is only reported as a slot while it carries something, so an emptied holder does not appear in the report at all, and the code that clears a location only ran for slots the report still contained. The spool kept "<printer> - External" long after it had been taken off, and nothing would ever have cleared it
          - The same applies to an AMS unit that stops being reported, for instance an unplugged one: its slots are now released as well
          - A location that does not name this printer is still left alone, so anything set by hand survives

--- a/docs/changelog-1.3.0-draft.md
+++ b/docs/changelog-1.3.0-draft.md
@@ -6,7 +6,7 @@ between two builds. This file is the consolidated release block, written into
 CHANGELOG.md in place of those dev blocks when the release build is cut, not
 before.
 
-Every dev build after dev.11 has to be folded in here as well, or regenerate the
+Every dev build after dev.12 has to be folded in here as well, or regenerate the
 whole block from the dev blocks at release time.
 
 ## Draft
@@ -66,6 +66,15 @@ Version 1.3.0
       - The whole Web UI works on a phone. An AMS unit is one card there, with its header as the head and its slots as sections inside it, instead of four free floating tiles; the printer list, the spool tables and the API keys are cards with their labels above the values instead of a table behind a sideways scroll; and a dialog fits inside the screen
       - Every page keeps to the same width as the settings page, 1180 px, instead of stretching to the window, so the menu bar and the content under it line up and a wide screen no longer pulls a spool table or a log line across the whole desk
       - New ENVs: LEGACY_MODE, DATA_DIR, LOG_DIR, SUPERVISOR, LOG_MAX_SIZE_MB, LOG_KEEP_SERVER, LOG_KEEP_PRINTER, ALLOWED_HOSTS, AUTH_PASSWORD
+      - A finished print leaves a summary behind, opened from the "consumption booked" label on the card: result, start, end, duration, layers, and one row per filament with the slot it ran from, the grams and the spool it was booked onto
+         - The table is every filament of the sliced file and what became of it, so a line without a booking reads as part of the plate rather than as something the service mislaid. A filament that was not booked carries the reason, and the two failures are named apart because only one can be acted on: a slot printed it and no Spoolman spool is connected or assigned to that slot, or no slot of the printer carried it at all
+         - Filaments are named the way the slot tables name them, vendor, material and colour with the swatch in front, taken from the record the booking wrote or from the slot where the printer itself named it in print.mapping
+         - An error the printer names is carried into it, including the code a print stopped by hand reports. It arrives a report after the state does, so it is collected across reports rather than read from the one that ends the job
+         - The summary is held in memory only. It is dropped when the next print starts and does not survive a restart
+      - The card returns to idle on its own once a print has been over for "Clear print result after", ten minutes by default, 0 to keep it until it is cleared by hand. Next to the booking label is a Clear button carrying the countdown, which does it now; the summary stays reachable as "Last print" until the next print starts
+      - The card says more about a running print: when it started, how long it has been going, when it is expected to end, and a badge naming what the printer is busy with when it is not laying down filament, amber while it is getting ready
+         - The printer reports no start time of its own, so it is measured here and left out rather than invented after a restart mid print. The time left is stated at the precision the printer has, "~ 3 min" or "~ 6 Days 4 hours 30 min", and a paused print shows what it still needs instead of an end time that would move for as long as the pause lasts
+         - Stage names are the ones the community has settled on rather than a published table, so a code nobody has a name for is shown as its number
    - Fixes:
       - A spool is created with the weight the AMS reports instead of always starting at 100 % (issue #59)
       - Consumption is booked onto the right spool when two loaded spools look alike, and no longer onto a spool that never printed it
@@ -85,6 +94,7 @@ Version 1.3.0
       - The confirmation dialogs of "Merge Spool", "Create Spool" and "Create Filament & Spool" fit a phone. They carry the tray UUID of the slot, 32 characters with nothing to break at, so the table could not shrink below its own content and a merge ended mid word. A value may break inside a word now, and on a phone the rows stack, the label above the value it names
       - Several dashboard fixes: the theme no longer flashes on page load, the confirmation dialog stays usable, the legacy table uses the full width, and a spool the printer cannot identify is labelled "3rd party"
       - The API is no longer reachable from every other website the browser has open. Every response carried "Access-Control-Allow-Origin: *", which tells the browser to hand the answer to any page that asks, so a page on any other site could read the printer list and the settings of an installation on the local network and could write to them as well. The header is gone, and a request that changes something is refused when it comes from another site, while a call from a script or a home automation, which carries no site at all, keeps working
+      - The layer counter no longer runs past the end of the print. A 26 layer plate showed "Layer 27 / 26" and 104% on its last layer, because the sliced file reports the highest layer index while the printer reports the layer count once it has finished, and one was added to both
    - Development:
       - Node 22, and the README is rebuilt around G-code tracking with new screenshots
       - One projection for what a client sees of a slot, one consumption match, and the rules both sides apply live in public/shared.js instead of in two implementations

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bambulab-ams-spoolman-filamentstatus",
-  "version": "1.3.0-dev.11",
+  "version": "1.3.0-dev.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bambulab-ams-spoolman-filamentstatus",
-      "version": "1.3.0-dev.11",
+      "version": "1.3.0-dev.12",
       "license": "ISC",
       "dependencies": {
         "adm-zip": "^0.6.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "mqtt": "^5.15.2"
   },
   "name": "bambulab-ams-spoolman-filamentstatus",
-  "version": "1.3.0-dev.11",
+  "version": "1.3.0-dev.12",
   "main": "app.js",
   "type": "module",
   "engines": {

--- a/src/config.js
+++ b/src/config.js
@@ -32,7 +32,7 @@ export const apiKeysPath = path.join(dataDir, "apikeys.json");
 // brings the service back on its own or depends on the container policy.
 export const supervised = process.env.SUPERVISED === "1";
 
-export const version = "1.3.0-dev.11";
+export const version = "1.3.0-dev.12";
 export const PORT = 4000;
 export const RECONNECT_INTERVAL = 60000;
 


### PR DESCRIPTION
Cuts a dev build carrying #128 and #129.

`package.json`, `package-lock.json` and `src/config.js` are bumped together: the publish workflow compares the tag against `package.json`, and `src/config.js` is what the Web UI and the diagnostics bundle report.

## The changelog correction

The print summary, the reset and the running print card were written into the **dev.11** section while that tag was already published. The release body of `v1.3.0-dev.11` does not carry them, so the changelog claimed they shipped in a build that never had them. They move into a section of their own; what stays in dev.11 is the location fix that really did ship in it.

Same work folded into `docs/changelog-1.3.0-draft.md`, which the 1.3.0 release block is written from, and the note at the top of that file now names dev.12 as the point everything after it has to be folded in from.

🤖 Generated with [Claude Code](https://claude.com/claude-code)