### PR TITLE
A printer reconnects after a network drop even while Spoolman is down

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,12 @@
 -----------------------------------------------------------------------------------------------
+Version 1.3.0-dev.14
+   - Fixes:
+      - A printer reconnects after a network drop even while Spoolman is still unreachable. Measured on 2026-09-05: a drop took both connections down within nine seconds, the MQTT close handler said it would retry "within 20 seconds via the monitor loop", and for the five minutes until the process was restarted there was not one reconnect attempt and not one reachability check, while the printer answered on port 8883 the whole time
+         - The monitor loop is the only thing that reconnects MQTT, and it idled for as long as Spoolman was down, on the grounds that there would be nothing to write AMS data to. That made a printer connection hostage to an unrelated service
+         - Nothing is written to Spoolman by keeping the connection up: the message handler refuses to process a report while Spoolman is down, and always did. That guard is what the idling was really for, and it sits where it belongs. Staying connected also means the printer is already there when Spoolman comes back, instead of waiting out another interval first
+      - The Spoolman health check says why it failed. It used to discard the error, so an outage produced a run of identical lines saying only "unreachable"; no route to the host, a refused connection, a timeout and an answer that is not JSON are four different problems with four different answers
+
+-----------------------------------------------------------------------------------------------
 Version 1.3.0-dev.12
    - Features:
       - A finished print leaves a summary behind. "consumption booked" is a button now, and it opens what the print actually did: the result, when it started and ended, how long it took, how many layers, and one row per filament with the slot it ran from, the grams and the spool they were booked onto

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 -----------------------------------------------------------------------------------------------
-Version 1.3.0-dev.13
+Unreleased
    - Fixes:
       - A printer reconnects after a network drop even while Spoolman is still unreachable. Measured on 2026-09-05: a drop took both connections down within nine seconds, the MQTT close handler said it would retry "within 20 seconds via the monitor loop", and for the five minutes until the process was restarted there was not one reconnect attempt and not one reachability check, while the printer answered on port 8883 the whole time
          - The monitor loop is the only thing that reconnects MQTT, and it idled for as long as Spoolman was down, on the grounds that there would be nothing to write AMS data to. That made a printer connection hostage to an unrelated service

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 -----------------------------------------------------------------------------------------------
-Version 1.3.0-dev.14
+Version 1.3.0-dev.13
    - Fixes:
       - A printer reconnects after a network drop even while Spoolman is still unreachable. Measured on 2026-09-05: a drop took both connections down within nine seconds, the MQTT close handler said it would retry "within 20 seconds via the monitor loop", and for the five minutes until the process was restarted there was not one reconnect attempt and not one reachability check, while the printer answered on port 8883 the whole time
          - The monitor loop is the only thing that reconnects MQTT, and it idled for as long as Spoolman was down, on the grounds that there would be nothing to write AMS data to. That made a printer connection hostage to an unrelated service

--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -288,7 +288,16 @@ build their Spoolman payload from.
   unqueued `rotateNow()` because it is already inside the queue.
 - **Reconnects are driven only by `monitorPrinters()`.** The MQTT `close` and
   `error` handlers must not reschedule themselves. Two independent retry paths
-  used to race.
+  used to race. Because it is the only driver, nothing else may be allowed to
+  stop it: it used to idle while Spoolman was down, and a network drop that took
+  both out then left the printer disconnected for as long as Spoolman stayed
+  unreachable, with the close handler still promising a retry. `servicePrinters()`
+  is one pass of it, split out so a pass can be asserted on; the loop itself
+  never returns.
+- **Spoolman being down stops processing, never connecting.** The guard belongs
+  in `handleMqttMessage()`, which refuses to process a report without Spoolman,
+  and it is already there. Anywhere else it turns an unrelated outage into a
+  second one.
 - **`printer.blockMqttUpdates` serialises message handling.** Messages arriving
   during processing are dropped, not queued.
 

--- a/src/config.js
+++ b/src/config.js
@@ -34,7 +34,6 @@ export const supervised = process.env.SUPERVISED === "1";
 
 export const version = "1.3.0-dev.12";
 export const PORT = 4000;
-export const RECONNECT_INTERVAL = 60000;
 
 // Raw environment values. They seed settings.json and printers.json on the
 // first run only; afterwards those files own the values. This is the only

--- a/src/mqtt.js
+++ b/src/mqtt.js
@@ -1,7 +1,7 @@
 import mqtt from "mqtt";
 import got from "got";
 import * as net from "node:net";
-import { serverLogFilePath, RECONNECT_INTERVAL } from "./config.js";
+import { serverLogFilePath } from "./config.js";
 import { settings, spoolmanUrl, legacyMode } from "./settings.js";
 import { originalConsoleLog } from "./logger.js";
 import { state } from "./state.js";
@@ -1696,8 +1696,22 @@ function printerStillOffline(printer, now) {
  * This is the single retry driver for MQTT. On every offline check interval each
  * enabled printer is probed with a plain TCP connect before setupMqtt is
  * attempted, so an unreachable printer costs one short timeout rather than a
- * hanging MQTT handshake. The whole loop idles while Spoolman is down, since
- * there would be nothing to write AMS data to.
+ * hanging MQTT handshake.
+ *
+ * It keeps running while Spoolman is down. It used to idle instead, on the
+ * grounds that there would be nothing to write AMS data to, and because this is
+ * the only thing that reconnects MQTT that made a printer connection hostage to
+ * an unrelated service. Measured on 2026-09-05: a network drop took both down
+ * within nine seconds, the close handler promised a retry "within 20 seconds
+ * via the monitor loop", and for the five minutes until the process was
+ * restarted there was not one reconnect attempt and not one reachability check,
+ * while the printer answered on port 8883 the whole time.
+ *
+ * Nothing is written to Spoolman by keeping the connection up:
+ * `handleMqttMessage()` refuses to process a report while Spoolman is down, and
+ * always did. That guard is what the idling was really for, and it sits where
+ * it belongs. Staying connected also means the printer is already there when
+ * Spoolman comes back, rather than waiting out another interval first.
  *
  * A printer that does not answer is asked again on a growing interval rather
  * than on every tick, see `printerStillOffline()`. The loop keeps ticking at the
@@ -1708,58 +1722,90 @@ function printerStillOffline(printer, now) {
  */
 export async function monitorPrinters(printers) {
     while (true) {
-        if (state.spoolmanStatus === "Disconnected") {
-            await sleep(RECONNECT_INTERVAL);
+        await servicePrinters(printers);
+        await sleep(settings.OFFLINE_CHECK_INTERVAL);
+    }
+}
+
+/**
+ * One pass of the monitor loop over the printer list.
+ *
+ * Split out of `monitorPrinters()` so that a pass can be run and asserted on.
+ * The loop itself never returns, so a test could only start it and hope; what
+ * needs proving is what one pass does, and in particular that it does it while
+ * Spoolman is down.
+ *
+ * @param {object[]} printers - the printer list
+ */
+export async function servicePrinters(printers) {
+    for (const printer of printers) {
+        if (!printer.monitoringEnabled) {
+            printer.mqttRunning = false;
+            printer.mqttStatus = "Disabled";
             continue;
         }
 
-        for (const printer of printers) {
-            if (!printer.monitoringEnabled) {
-                printer.mqttRunning = false;
-                printer.mqttStatus = "Disabled";
-                continue;
-            }
+        const now = Date.now();
+        // Not yet due: this printer failed its last check and is waiting out
+        // its backoff. A connected one has no wait, so it is never skipped.
+        if (printer.nextCheckAt && now < printer.nextCheckAt) continue;
 
-            const now = Date.now();
-            // Not yet due: this printer failed its last check and is waiting out
-            // its backoff. A connected one has no wait, so it is never skipped.
-            if (printer.nextCheckAt && now < printer.nextCheckAt) continue;
+        try {
+            const isAlive = await checkPrinterAvailability(printer.ip, 8883);
 
-            try {
-                const isAlive = await checkPrinterAvailability(printer.ip, 8883);
+            if (isAlive) {
+                if (printerIsBack(printer)) {
+                    console.log(printer.name, printer.logFilePath, `Printer ${printer.id} with IP ${printer.ip} is reachable again`);
+                }
 
-                if (isAlive) {
-                    if (printerIsBack(printer)) {
-                        console.log(printer.name, printer.logFilePath, `Printer ${printer.id} with IP ${printer.ip} is reachable again`);
-                    }
-
-                    if (!printer.mqttRunning && !printer.isReconnecting) {
-                        if (settings.MAX_RETRIES > 0 && printer.reconnectAttempts >= settings.MAX_RETRIES) {
-                            printer.monitoringEnabled = false;
-                            printer.mqttRunning = false;
-                            printer.mqttStatus = "Disabled";
-                            console.log(printer.name, printer.logFilePath, "Monitoring disabled (max retries reached).");
-                            continue;
-                        }
-                        console.log(printer.name, printer.logFilePath, `MQTT not running for Printer: ${printer.id}, attempting to reconnect...`);
-                        setupMqtt(printer);
-                    }
-                } else {
+                if (!printer.mqttRunning && !printer.isReconnecting) {
                     if (settings.MAX_RETRIES > 0 && printer.reconnectAttempts >= settings.MAX_RETRIES) {
                         printer.monitoringEnabled = false;
                         printer.mqttRunning = false;
                         printer.mqttStatus = "Disabled";
-                        console.log(printer.name, printer.logFilePath, "Printer is unreachable and the retry limit is exceeded, monitoring disabled.");
+                        console.log(printer.name, printer.logFilePath, "Monitoring disabled (max retries reached).");
                         continue;
                     }
-                    printerStillOffline(printer, now);
+                    console.log(printer.name, printer.logFilePath, `MQTT not running for Printer: ${printer.id}, attempting to reconnect...`);
+                    setupMqtt(printer);
                 }
-            } catch (error) {
-                console.error(printer.name, printer.logFilePath, `Error monitoring Printer: ${printer.id} - ${error.message}`);
+            } else {
+                if (settings.MAX_RETRIES > 0 && printer.reconnectAttempts >= settings.MAX_RETRIES) {
+                    printer.monitoringEnabled = false;
+                    printer.mqttRunning = false;
+                    printer.mqttStatus = "Disabled";
+                    console.log(printer.name, printer.logFilePath, "Printer is unreachable and the retry limit is exceeded, monitoring disabled.");
+                    continue;
+                }
+                printerStillOffline(printer, now);
             }
+        } catch (error) {
+            console.error(printer.name, printer.logFilePath, `Error monitoring Printer: ${printer.id} - ${error.message}`);
         }
-        await sleep(settings.OFFLINE_CHECK_INTERVAL);
     }
+}
+
+/**
+ * Names why a request to Spoolman failed, in one short phrase.
+ *
+ * The health checks used to discard the error entirely, so an outage produced a
+ * run of identical lines that said only "unreachable". These are different
+ * problems: no route to the host is a network question, a refused connection
+ * means the address is right and nothing is listening, a timeout means something
+ * answered too slowly to be usable, and a parse failure means the endpoint is
+ * not the Spoolman anybody thinks it is.
+ *
+ * The code is preferred over the message because `got` wraps the message in its
+ * own text, and the code is what a search engine and the user's router agree on.
+ *
+ * @param {Error} err - whatever the request threw
+ * @returns {string} a short reason, never empty
+ */
+export function describeRequestError(err) {
+    const code = err?.code || err?.cause?.code;
+    if (code) return code;
+    if (err instanceof SyntaxError) return "the answer was not JSON";
+    return err?.message || "no reason given";
 }
 
 /**
@@ -1783,8 +1829,9 @@ export async function monitorSpoolman() {
             } else {
                 console.error("Server", serverLogFilePath, "Spoolman reported an unhealthy status, retrying...");
             }
-        } catch {
-            console.error("Server", serverLogFilePath, "Spoolman is unreachable. Retrying in 30 seconds...");
+        } catch (err) {
+            console.error("Server", serverLogFilePath,
+                `Spoolman is unreachable (${describeRequestError(err)}). Retrying in 30 seconds...`);
         }
         await sleep(30000);
     }
@@ -1811,8 +1858,15 @@ export async function monitorSpoolmanBackground() {
                 console.error("Server", serverLogFilePath, "Spoolman reported an unhealthy status!");
                 state.spoolmanStatus = "Disconnected";
             }
-        } catch {
-            console.error("Server", serverLogFilePath, "Spoolman is unreachable. Retrying in 60 seconds...");
+        } catch (err) {
+            // The reason, not just the fact. This used to swallow the error, and
+            // an outage on 2026-09-05 then produced five identical lines saying
+            // nothing: whether the address was still unroutable, whether the
+            // request timed out, or whether the endpoint answered something
+            // unparseable are three different problems with three different
+            // answers, and the log could not tell them apart.
+            console.error("Server", serverLogFilePath,
+                `Spoolman is unreachable (${describeRequestError(err)}). Retrying in 60 seconds...`);
             state.spoolmanStatus = "Disconnected";
         }
         await sleep(60000);

--- a/test/reconnect.test.js
+++ b/test/reconnect.test.js
@@ -1,0 +1,101 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "fs-extra";
+import os from "os";
+import path from "path";
+
+// The write paths have to stay out of a real installation, and these are read
+// once at import time, so they are set before the first import below.
+const dir = fs.mkdtempSync(path.join(os.tmpdir(), "ams-reconnect-"));
+process.env.DATA_DIR = path.join(dir, "printers");
+process.env.LOG_DIR = path.join(dir, "logs");
+fs.ensureDirSync(process.env.DATA_DIR);
+fs.ensureDirSync(process.env.LOG_DIR);
+
+const { servicePrinters, describeRequestError } = await import("../src/mqtt.js");
+const { state } = await import("../src/state.js");
+const { settings } = await import("../src/settings.js");
+
+/** A printer that is enabled, not connected, and points at nothing. */
+function offlinePrinter() {
+    return {
+        id: "TESTPRINTER0001",
+        name: "Test Printer",
+        // 203.0.113.0/24 is reserved for documentation and routes nowhere, so
+        // the reachability probe fails on its own timeout rather than reaching
+        // something on the machine running the tests.
+        ip: "203.0.113.1",
+        logFilePath: path.join(process.env.LOG_DIR, "TESTPRINTER0001.log"),
+        monitoringEnabled: true,
+        mqttRunning: false,
+        mqttStatus: "Disconnected",
+        reconnectAttempts: 0,
+        offlineChecks: 0,
+        nextCheckAt: 0,
+        offlineWaitLogged: null,
+    };
+}
+
+test("the printer monitor keeps working while Spoolman is down", async () => {
+    // It used to idle for as long as Spoolman was unreachable, and it is the
+    // only thing that reconnects MQTT. Measured on 2026-09-05: a network drop
+    // took both down within nine seconds, and for the five minutes until the
+    // process was restarted there was not one reconnect attempt and not one
+    // reachability check, while the printer answered the whole time.
+    const before = state.spoolmanStatus;
+    const interval = settings.OFFLINE_CHECK_INTERVAL;
+
+    try {
+        state.spoolmanStatus = "Disconnected";
+        // Short enough that a tick happens inside the window below
+        settings.OFFLINE_CHECK_INTERVAL = 20000;
+
+        const printer = offlinePrinter();
+        await servicePrinters([printer]);
+
+        // The probe was made: an unreachable printer comes back with its
+        // backoff armed, which is the loop having looked at it at all.
+        assert.ok(printer.nextCheckAt > 0, "the printer was never probed while Spoolman was down");
+    } finally {
+        state.spoolmanStatus = before;
+        settings.OFFLINE_CHECK_INTERVAL = interval;
+    }
+});
+
+test("a printer nobody is monitoring is still left alone while Spoolman is down", async () => {
+    // Removing the Spoolman gate must not turn the loop into something that
+    // touches printers the user switched off.
+    const before = state.spoolmanStatus;
+
+    try {
+        state.spoolmanStatus = "Disconnected";
+
+        const printer = { ...offlinePrinter(), monitoringEnabled: false };
+        await servicePrinters([printer]);
+
+        assert.equal(printer.mqttStatus, "Disabled");
+        assert.equal(printer.nextCheckAt, 0, "a disabled printer must not be probed");
+    } finally {
+        state.spoolmanStatus = before;
+    }
+});
+
+test("a failed request is named by its code rather than swallowed", () => {
+    // The health checks used to discard the error, so an outage produced a run
+    // of identical lines saying only "unreachable". These are four different
+    // problems and the log could not tell them apart.
+    assert.equal(describeRequestError({ code: "EHOSTUNREACH" }), "EHOSTUNREACH");
+    assert.equal(describeRequestError({ code: "ECONNREFUSED" }), "ECONNREFUSED");
+    assert.equal(describeRequestError({ code: "ETIMEDOUT" }), "ETIMEDOUT");
+
+    // got wraps the original in `cause`, which is where the code really sits
+    assert.equal(describeRequestError({ message: "x", cause: { code: "ECONNRESET" } }), "ECONNRESET");
+
+    // An endpoint that answers something that is not Spoolman
+    assert.equal(describeRequestError(new SyntaxError("Unexpected token <")), "the answer was not JSON");
+
+    // Anything else still says something rather than nothing
+    assert.equal(describeRequestError(new Error("boom")), "boom");
+    assert.equal(describeRequestError(undefined), "no reason given");
+    assert.equal(describeRequestError({}), "no reason given");
+});


### PR DESCRIPTION
Found while running #132 against the real P2S. A network drop took both connections down within nine seconds:

```
16:12:49  Server  - Error fetching spools from Spoolman: EHOSTUNREACH
16:12:49  Server  - Spoolman is currently unreachable...
16:12:58  P2S     - MQTT error: write EPIPE
16:12:58  P2S     - Connection closed, will retry within 20 second(s) via the monitor loop...
```

For the five minutes until the process was restarted there was **not one reconnect attempt and not one reachability check**, while the printer answered on port 8883 the whole time. The promise in that last line was never going to be kept.

## The cause

`monitorPrinters()` is the only thing that reconnects MQTT, which the invariant in `src/AGENTS.md` says outright, and it opened with this:

```js
while (true) {
    if (state.spoolmanStatus === "Disconnected") {
        await sleep(RECONNECT_INTERVAL);
        continue;          // the whole loop idles
    }
```

That makes a printer connection hostage to an unrelated service. One outage becomes two.

The gate's stated reason, in its own doc comment, was that "there would be nothing to write AMS data to". **That guard exists already and sits where it belongs**: `handleMqttMessage()` refuses to process a report while Spoolman is down, and always did. Keeping the connection up writes nothing to Spoolman. It also means the printer is already there when Spoolman comes back rather than waiting out another interval first.

`RECONNECT_INTERVAL` was the gate's own constant and had no other reader, so it goes with it.

## The health check now says why

Both Spoolman loops discarded the error, so the outage produced five identical lines saying only "unreachable". No route to the host, a refused connection, a timeout, and an answer that is not JSON are four different problems with four different answers, and the log could not tell them apart.

**Why Spoolman itself did not recover for those five minutes is still unexplained, and nothing here claims to fix it.** A fresh Node process made the exact same call in 14 ms while the running service was on its fourth failed retry. Without the reason in the log there is nothing to go on, which is what this part is for; the next occurrence will say whether the address stayed unroutable or something else happened.

## Verified against the P2S

With the Spoolman endpoint pointed at a closed port, so the service really believed it was down:

- The monitor loop kept working. The printer was moved to a dead address and the loop probed it and applied its backoff throughout — 20 s, 40 s, 1 min 20 s. On `main` these 75 seconds produce nothing at all.
- The new line reads `Spoolman is unreachable (ECONNREFUSED)`.
- On restoring both: **MQTT was back at 18:17:02 and Spoolman at 18:17:25.** The printer recovered 23 seconds before the service it had been waiting on, which is the point.

## Tests

424 pass. `servicePrinters()` is one pass of the loop, split out because the loop never returns and a test could otherwise only start it and hope. Covered: a pass happens while Spoolman is down, a printer whose monitoring is switched off is still left alone, and the error reason for the four shapes a failure arrives in.

Branched off `main` rather than off #132, so it can be reviewed and merged on its own. Its changelog entries go under `Unreleased`, the same block #132 writes into, since `dev.12` is what is published and the version bump is what names the block. Both prepend to `CHANGELOG.md`, so whichever merges second conflicts, and the resolution is to put both sets of entries in that one block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


