### PR TITLE
chore: bump the version to 1.3.0-dev.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 -----------------------------------------------------------------------------------------------
-Unreleased
+Version 1.3.0-dev.15
    - Fixes:
       - The external spool holder no longer shows and vanishes on a P1S (issue #131). The printer sends delta reports that carry the AMS block and leave vt_tray out, and each of those was read as an empty holder: the External slot was released and its Spoolman location cleared, and the next full report created it again. Read off the raw MQTT trace of the reporter's P1S: 167 delta reports with the AMS block and no vt_tray against 27 full reports that all carried it, and not one report with the key present but empty
          - A report that does not mention the holder now means nothing changed, and only a report that carries the key, an empty holder included, replaces what the last one said. The memory starts empty on every connection, so a holder emptied while nobody was listening is corrected by the first full report

--- a/docs/changelog-1.3.0-draft.md
+++ b/docs/changelog-1.3.0-draft.md
@@ -6,7 +6,7 @@ between two builds. This file is the consolidated release block, written into
 CHANGELOG.md in place of those dev blocks when the release build is cut, not
 before.
 
-Every dev build after dev.14 has to be folded in here as well, or regenerate the
+Every dev build after dev.15 has to be folded in here as well, or regenerate the
 whole block from the dev blocks at release time.
 
 ## Draft
@@ -105,6 +105,7 @@ Version 1.3.0
       - The layer counter no longer runs past the end of the print. A 26 layer plate showed "Layer 27 / 26" and 104% on its last layer, because the sliced file reports the highest layer index while the printer reports the layer count once it has finished, and one was added to both
       - A printer reconnects after a network drop even while Spoolman is still unreachable. The monitor loop is the only thing that reconnects MQTT, and it idled for as long as Spoolman was down, which made a printer connection hostage to an unrelated service. Nothing is written to Spoolman by keeping the connection up: the message handler refuses to process a report while Spoolman is down, and always did
       - The Spoolman health check says why it failed. No route to the host, a refused connection, a timeout and an answer that is not JSON are four different problems with four different answers, and all four used to read as "unreachable"
+      - The external spool holder no longer shows and vanishes on a P1S (issue #131). The printer sends delta reports that carry the AMS block and leave the holder out, and each of those was read as an empty holder. A report that does not mention the holder now means nothing changed, and only a report that carries it replaces what the last one said
       - A P1 outside a print no longer shows "Stage 255". It reports 255 where an X1 and a P2S report -1, and both read as no stage at all
       - Two print stages are named instead of shown as a number: 51 is the calibration lines and 54 is the heatbed coming up to temperature, both amber because neither has started the plate. Everything else nothing has named still falls back to its number
    - Development:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bambulab-ams-spoolman-filamentstatus",
-  "version": "1.3.0-dev.14",
+  "version": "1.3.0-dev.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bambulab-ams-spoolman-filamentstatus",
-      "version": "1.3.0-dev.14",
+      "version": "1.3.0-dev.15",
       "license": "ISC",
       "dependencies": {
         "adm-zip": "^0.6.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "mqtt": "^5.15.2"
   },
   "name": "bambulab-ams-spoolman-filamentstatus",
-  "version": "1.3.0-dev.14",
+  "version": "1.3.0-dev.15",
   "main": "app.js",
   "type": "module",
   "engines": {

--- a/src/config.js
+++ b/src/config.js
@@ -32,7 +32,7 @@ export const apiKeysPath = path.join(dataDir, "apikeys.json");
 // brings the service back on its own or depends on the container policy.
 export const supervised = process.env.SUPERVISED === "1";
 
-export const version = "1.3.0-dev.14";
+export const version = "1.3.0-dev.15";
 export const PORT = 4000;
 
 /** The spellings a boolean environment variable is accepted in. */


### PR DESCRIPTION
## Summary

- `package.json`, `package-lock.json` and `src/config.js` move to 1.3.0-dev.15 together, because the publish workflow compares the tag against `package.json` and `src/config.js` is what the Web UI reports.
- The Unreleased block of the changelog becomes the dev.15 block: the external holder surviving the delta reports of a P1S, #141.
- The release draft gets that fix.

This build exists for issue #131: the reporter is waiting for the fix, and it is the only change since dev.14.

## Test plan

- [x] `npm test`, 572 passing
- [x] After the merge, tag `v1.3.0-dev.15` on main and let the publish workflow build the image

🤖 Generated with [Claude Code](https://claude.com/claude-code)
