### PR TITLE
feat: the Logs page carries its choices as a toolbar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,12 @@
 -----------------------------------------------------------------------------------------------
+Unreleased
+   - Features:
+      - The Logs page carries its choices as controls, not as a heading. The name in "Backend Logs for: P1S" was the picker over the logs, and a printer's raw MQTT trace was a group inside its menu; the first person who needed a trace did not find it there (issue #131). A toolbar above the log now holds a Source button over the server and the printers, a Log / Raw MQTT trace switch for a printer, and the download
+         - Next to the download the page says what it shows and what the download would carry: "refreshes every 5 s · 2 files, 1.3 MB" for a log, "last 50 reports · refreshes every 5 s · 3 files, 41 MB" for a trace, and "capture is off" in front when the trace of that printer is not being written. The box then says where the capture is switched on rather than showing an empty file
+         - The switch changes the file in place and writes it into the address, so a link to a trace still opens the trace, and picking another printer while reading traces opens that printer's trace. The title under the toolbar names the file on disk, which is what a bug report ends up naming
+         - The log endpoint answers the size of the file set, the file name and whether the capture is on, next to the line count it already answered
+
+-----------------------------------------------------------------------------------------------
 Version 1.3.0-dev.15
    - Fixes:
       - The external spool holder no longer shows and vanishes on a P1S (issue #131). The printer sends delta reports that carry the AMS block and leave vt_tray out, and each of those was read as an empty holder: the External slot was released and its Spoolman location cleared, and the next full report created it again. Read off the raw MQTT trace of the reporter's P1S: 167 delta reports with the AMS block and no vt_tray against 27 full reports that all carried it, and not one report with the key present but empty

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 Unreleased
    - Features:
       - The Logs page carries its choices as controls, not as a heading. The name in "Backend Logs for: P1S" was the picker over the logs, and a printer's raw MQTT trace was a group inside its menu; the first person who needed a trace did not find it there (issue #131). A toolbar above the log now holds a Source button over the server and the printers, a Log / Raw MQTT trace switch for a printer, and the download
-         - Next to the download the page says what it shows and what the download would carry: "refreshes every 5 s · 2 files, 1.3 MB" for a log, "last 50 reports · refreshes every 5 s · 3 files, 41 MB" for a trace, and "capture is off" in front when the trace of that printer is not being written. The box then says where the capture is switched on rather than showing an empty file
+         - Next to the download the page says what it shows and what the download would carry: "refreshes every 5 s · 2 files, 1.3 MB" for a log, "last 50 reports · refreshes every 5 s · 3 files, 41 MB" for a trace, and "capture disabled" in front when the trace of that printer is not being written. The box then says where to enable it rather than showing an empty file
          - The switch changes the file in place and writes it into the address, so a link to a trace still opens the trace, and picking another printer while reading traces opens that printer's trace. The title under the toolbar names the file on disk, which is what a bug report ends up naming
          - The log endpoint answers the size of the file set, the file name and whether the capture is on, next to the line count it already answered
 

--- a/public/logs.html
+++ b/public/logs.html
@@ -20,15 +20,36 @@
         <div id="menu-root"></div>
     </div>
     <div class="page-width log-page">
-        <!-- The name is a picker over the logs, filled by menu.js -->
-        <h3 class="log-title">Backend Logs for: <span id="headline"></span></h3>
+        <!-- Every choice the page offers is on this one line: which log, which
+             of a printer's two files, and the download. The picker used to be
+             the headline itself, and the trace a group inside its menu, which
+             the first person who needed one did not find. -->
+        <div class="log-toolbar">
+            <div class="log-field">
+                <span class="log-field-label">Source</span>
+                <!-- The picker over the logs, filled by menu.js -->
+                <span id="headline"></span>
+            </div>
+            <!-- Hidden for the server log, which has no trace -->
+            <div class="log-field" id="log-stream-field" hidden>
+                <span class="log-field-label">Show</span>
+                <div class="log-switch" id="log-stream" role="group" aria-label="Which file of the printer">
+                    <button type="button" data-stream="log" aria-pressed="true">Log</button>
+                    <button type="button" data-stream="mqtt" aria-pressed="false">Raw MQTT trace</button>
+                </div>
+            </div>
+            <div class="log-toolbar-end">
+                <span class="log-meta" id="log-meta"></span>
+                <button id="download-logs" class="log-button">Download...</button>
+            </div>
+        </div>
+        <h3 class="log-title">
+            <span id="log-title"></span>
+            <!-- The file on disk, which is what a bug report ends up naming -->
+            <span class="log-file" id="log-file"></span>
+        </h3>
         <div id="log-box">
             <div id="logs"></div>
-        </div>
-        <!-- Under the log it downloads, and always on screen: the box above it
-             takes the height that is left rather than growing past it -->
-        <div class="log-actions">
-            <button id="download-logs" class="log-button">Download this log file...</button>
         </div>
     </div>
     <script src="menu.js"></script>

--- a/public/logs.js
+++ b/public/logs.js
@@ -1,7 +1,12 @@
 document.addEventListener("DOMContentLoaded", () => {
   const logContainer = document.getElementById("logs");
   const logBox = document.getElementById("log-box");
-  let logAPI;
+  const streamField = document.getElementById("log-stream-field");
+  const streamButtons = [...document.querySelectorAll("#log-stream button")];
+  const titleEl = document.getElementById("log-title");
+  const fileEl = document.getElementById("log-file");
+  const metaEl = document.getElementById("log-meta");
+  const downloadBtn = document.getElementById("download-logs");
   let userScrolling = false; // Variable to detect manual scrolling
 
   // Menu bar, including the dark mode button
@@ -15,33 +20,68 @@ document.addEventListener("DOMContentLoaded", () => {
 
   const printerSerial = getQueryParam("serial");
   const name = getQueryParam("name");
+  const isServer = name === "server";
+
+  if (!isServer && !printerSerial) {
+    logContainer.innerHTML = '<p>Error: No printer serial provided in the URL.</p>';
+    return;
+  }
+
   // The raw MQTT trace of a printer: a file of its own next to the log, so it
   // is the same page against a different stream rather than a page of its own.
-  const stream = getQueryParam("stream") === "mqtt" ? "&stream=mqtt" : "";
+  // The switch changes it in place and writes it into the address, so a link
+  // to a trace still opens the trace.
+  let stream = !isServer && getQueryParam("stream") === "mqtt" ? "mqtt" : "log";
 
   // A trace line is a whole printer report rather than a sentence, several
   // kilobytes of it, and the page reloads every five seconds. Asking for the
   // same 250 lines would be megabytes over the wire per refresh, for a wall of
   // text nobody reads on screen: the file is what gets downloaded and analysed.
-  const limit = stream ? 50 : 250;
+  const limitFor = which => (which === "mqtt" ? 50 : 250);
+  const REFRESH_MS = 5000;
 
-  // The headline names the log and is the picker over the others; menu.js
-  // fills it once the printer list is there. See renderTitlePicker().
-  if (name === "server") {
-    logAPI = `./api/logs/server?limit=${limit}`;
-  } else if (printerSerial) {
-    logAPI = `./api/logs/${printerSerial}?limit=${limit}${stream}`;
-  } else {
-    logContainer.innerHTML = '<p>Error: No printer serial provided in the URL.</p>';
-    return;
+  function apiUrl() {
+    if (isServer) return `./api/logs/server?limit=${limitFor(stream)}`;
+    return `./api/logs/${printerSerial}?limit=${limitFor(stream)}${stream === "mqtt" ? "&stream=mqtt" : ""}`;
   }
 
-  const downloadBtn = document.getElementById("download-logs");
+  function streamLabel() {
+    return stream === "mqtt" ? "Raw MQTT trace" : "Log";
+  }
+
+  /** Puts the switch, the address and the title into the state of `stream`. */
+  function renderStream() {
+    streamField.hidden = isServer;
+    for (const button of streamButtons) {
+      button.setAttribute("aria-pressed", String(button.dataset.stream === stream));
+    }
+
+    const url = new URL(window.location.href);
+    if (stream === "mqtt") url.searchParams.set("stream", "mqtt");
+    else url.searchParams.delete("stream");
+    history.replaceState(null, "", url);
+
+    titleEl.textContent = isServer ? "Server log" : `${name} · ${streamLabel()}`;
+    fileEl.textContent = "";
+    metaEl.textContent = "";
+    updateDownloadLabel(null);
+  }
+
+  for (const button of streamButtons) {
+    button.addEventListener("click", () => {
+      if (button.dataset.stream === stream) return;
+      stream = button.dataset.stream;
+      userScrolling = false;
+      renderStream();
+      loadLogs();
+    });
+  }
+
   if (downloadBtn) {
     downloadBtn.addEventListener("click", () => {
-      const downloadUrl = (name === "server")
+      const downloadUrl = isServer
         ? `./api/logs/server/download`
-        : `./api/logs/${printerSerial}/download${stream ? "?stream=mqtt" : ""}`;
+        : `./api/logs/${printerSerial}/download${stream === "mqtt" ? "?stream=mqtt" : ""}`;
 
       // A log carries every address and serial the service has seen, and these
       // files end up attached to bug reports, so the choice is asked rather
@@ -49,10 +89,10 @@ document.addEventListener("DOMContentLoaded", () => {
       // the printer reports, so the same choice matters more here.
       downloadWithExportMode({
         url: downloadUrl,
-        title: stream ? "Download the raw MQTT trace" : "Download the log",
-        what: name === "server"
+        title: stream === "mqtt" ? "Download the raw MQTT trace" : "Download the log",
+        what: isServer
           ? "The server log, including its rotated history."
-          : stream
+          : stream === "mqtt"
             ? `Every MQTT report captured from ${name}, including the rotated history.`
             : `The log of ${name}, including its rotated history.`,
       });
@@ -63,9 +103,54 @@ document.addEventListener("DOMContentLoaded", () => {
   // has to say which of the two it is rather than promising the wrong one.
   function updateDownloadLabel(fileCount) {
     if (!downloadBtn) return;
+    const kind = stream === "mqtt" ? "trace" : "log";
+    if (fileCount === null) {
+      downloadBtn.textContent = "Download...";
+      downloadBtn.disabled = true;
+      return;
+    }
+    downloadBtn.disabled = fileCount === 0;
     downloadBtn.textContent = fileCount > 1
-      ? `Download all ${fileCount} log files...`
-      : "Download this log file...";
+      ? `Download all ${fileCount} ${kind} files...`
+      : `Download this ${kind} file...`;
+  }
+
+  /** 41 MB, 1.3 MB, 120 KB: the size of a file set, as a download dialog says it. */
+  function formatBytes(bytes) {
+    if (bytes < 1024) return `${bytes} B`;
+    if (bytes < 1024 * 1024) return `${Math.round(bytes / 1024)} KB`;
+    const mb = bytes / (1024 * 1024);
+    if (mb < 10) return `${mb.toFixed(1)} MB`;
+    if (mb < 1024) return `${Math.round(mb)} MB`;
+    return `${(mb / 1024).toFixed(1)} GB`;
+  }
+
+  /**
+   * The line next to the download: what the box shows and what the download
+   * would carry. A trace says how many reports are on screen, because fifty is
+   * few and a reader looking for one report expects to scroll further than
+   * that; the log shows enough that nobody counts.
+   */
+  function describe(answer) {
+    const parts = [];
+    if (stream === "mqtt" && answer.capturing === false) parts.push("capture is off");
+    if (stream === "mqtt") parts.push(`last ${limitFor(stream)} reports`);
+    parts.push(`refreshes every ${REFRESH_MS / 1000} s`);
+
+    const files = answer.files ?? 1;
+    if (files === 0) parts.push("no file yet");
+    else if (typeof answer.bytes === "number") parts.push(`${files} ${files === 1 ? "file" : "files"}, ${formatBytes(answer.bytes)}`);
+    else parts.push(`${files} ${files === 1 ? "file" : "files"}`);
+    return parts.join(" · ");
+  }
+
+  /** What the box says when there is nothing to show, and why. */
+  function emptyMessage(answer) {
+    if (stream === "mqtt" && answer.capturing === false) {
+      return "The capture is off for this printer. It is switched on in the log detail dialog, \"Log\" in the Printers card of the Settings page.";
+    }
+    if (stream === "mqtt") return "No reports captured yet.";
+    return "No log files found.";
   }
 
   // Detect if the user is scrolling manually
@@ -76,14 +161,22 @@ document.addEventListener("DOMContentLoaded", () => {
 
   // Load logs dynamically
   async function loadLogs() {
+    const requested = stream;
     try {
-      const response = await fetch(logAPI);
+      const response = await fetch(apiUrl());
       if (!response.ok) throw new Error(`HTTP error! Status: ${response.status}`);
 
       const logData = await response.json();
+      // The stream was switched while this answer was on its way: it describes
+      // the file the page no longer shows
+      if (requested !== stream) return;
+
       updateDownloadLabel(logData.files ?? 1);
+      metaEl.textContent = describe(logData);
+      fileEl.textContent = logData.file ?? "";
+
       if (!logData.logs || logData.logs.length === 0) {
-        logContainer.innerHTML = "<p>No log files found.</p>";
+        logContainer.innerHTML = `<p>${emptyMessage(logData)}</p>`;
         return;
       }
 
@@ -101,12 +194,13 @@ document.addEventListener("DOMContentLoaded", () => {
         });
       }
     } catch (error) {
+      if (requested !== stream) return;
       console.error("Error loading logs:", error);
       logContainer.innerHTML = "<p>Error loading logs. Please try again later.</p>";
     }
   }
 
-  // Load logs periodically
+  renderStream();
   loadLogs(); // Initial load
-  setInterval(loadLogs, 5000); // Reload logs every 5 seconds
+  setInterval(loadLogs, REFRESH_MS); // Reload logs every 5 seconds
 });

--- a/public/logs.js
+++ b/public/logs.js
@@ -133,7 +133,7 @@ document.addEventListener("DOMContentLoaded", () => {
    */
   function describe(answer) {
     const parts = [];
-    if (stream === "mqtt" && answer.capturing === false) parts.push("capture is off");
+    if (stream === "mqtt" && answer.capturing === false) parts.push("capture disabled");
     if (stream === "mqtt") parts.push(`last ${limitFor(stream)} reports`);
     parts.push(`refreshes every ${REFRESH_MS / 1000} s`);
 
@@ -147,7 +147,7 @@ document.addEventListener("DOMContentLoaded", () => {
   /** What the box says when there is nothing to show, and why. */
   function emptyMessage(answer) {
     if (stream === "mqtt" && answer.capturing === false) {
-      return "The capture is off for this printer. It is switched on in the log detail dialog, \"Log\" in the Printers card of the Settings page.";
+      return "Raw MQTT capture is disabled for this printer. Enable it under Settings › Printers › Log.";
     }
     if (stream === "mqtt") return "No reports captured yet.";
     return "No log files found.";

--- a/public/menu.js
+++ b/public/menu.js
@@ -323,13 +323,16 @@ function panelHeading(text) {
 }
 
 /**
- * The picker that lives in the headline of the page.
+ * The picker over the printers, in the headline of the dashboard and in the
+ * toolbar of the log viewer.
  *
- * The dashboard headline reads "Loaded Spools on Bambu P2S" and the
- * log viewer "Backend Logs for: Bambu P2S". Those names are the control: the
- * name a page already writes is the one thing that changes when you pick, so
- * the pick belongs there rather than in the navigation, where it would say the
- * same thing a second time.
+ * The dashboard headline reads "Loaded Spools on Bambu P2S", and that name is
+ * the control: the name the page already writes is the one thing that changes
+ * when you pick, so the pick belongs there rather than in the navigation,
+ * where it would say the same thing a second time. The log viewer sets the
+ * same control as a plain button in its toolbar, next to the switch between a
+ * printer's log and its trace, because there it is one of several choices and
+ * has to look like one.
  *
  * Both pages give it a mount point of their own, `#printer-name` and
  * `#headline`, and this fills whichever one is on the page.
@@ -362,16 +365,6 @@ function renderTitlePicker() {
 
     host.appendChild(button);
 
-    // The serial says which physical machine this is, which is what a log gets
-    // attached to a bug report for. Next to the name rather than inside the
-    // control, so the thing you click is the name alone.
-    if (onLogs && current.note) {
-        const note = document.createElement("span");
-        note.className = "title-note";
-        note.textContent = current.note;
-        host.appendChild(note);
-    }
-
     if (!openable) return;
 
     const panel = document.createElement("div");
@@ -389,7 +382,10 @@ function renderTitlePicker() {
             heading = entry.heading;
             panel.appendChild(panelHeading(heading));
         }
-        panel.appendChild(panelEntry(entry.label, entry.action, { current: entry.current }));
+        // The serial says which physical machine an entry is, which is what a
+        // log gets attached to a bug report for, and it tells two printers of
+        // the same name apart
+        panel.appendChild(panelEntry(entry.label, entry.action, { current: entry.current, note: entry.note ?? "" }));
     }
 
     host.appendChild(panel);
@@ -408,12 +404,13 @@ function printerChoices() {
 }
 
 /**
- * What the log viewer's picker offers: the server log, every printer log, and
- * the raw MQTT trace of every printer.
+ * What the log viewer's picker offers: the server log and every printer.
  *
- * The traces are a group of their own rather than a switch on the page. They
- * are a different file with a different content, and a picker that already
- * names every log is where a reader looks for one more.
+ * A printer's raw MQTT trace is not an entry here. It used to be, as a group
+ * under the printers, and the one person who needed a trace did not find it
+ * there. It is the switch next to this picker now, on the page, where a second
+ * file of the same printer reads as what it is. Picking another printer keeps
+ * the stream: whoever is reading traces wants the next printer's trace.
  */
 function logChoices() {
     const params = new URLSearchParams(window.location.search);
@@ -431,21 +428,8 @@ function logChoices() {
             label: printer.name,
             heading: "Printers",
             note: printer.id,
-            current: printer.id === openSerial && !openTrace,
-            action: () => openPrinterLog(printer),
-        });
-    }
-
-    for (const printer of menuPrinters) {
-        choices.push({
-            // Named apart from the log above it: once picked, this label is what
-            // the headline carries, and two entries reading the same would leave
-            // the page unable to say which of the two files it is showing
-            label: `${printer.name} (raw MQTT)`,
-            heading: "Raw MQTT traces",
-            note: printer.id,
-            current: printer.id === openSerial && openTrace,
-            action: () => openPrinterLog(printer, true),
+            current: printer.id === openSerial,
+            action: () => openPrinterLog(printer, openTrace),
         });
     }
 

--- a/public/styles.css
+++ b/public/styles.css
@@ -882,22 +882,134 @@ button {
   font-size: 14px;
 }
 
-.log-title {
-  text-align: center;
-  margin-bottom: 10px;
+/* ---- Log page toolbar ----
+   One line with every choice the page offers: the source, the switch between a
+   printer's log and its raw MQTT trace, and the download with a line that says
+   what it would carry. The picker used to be the headline and the trace an
+   entry inside its menu, and the first person who needed a trace did not find
+   it: a choice has to look like a control, not like a heading. */
+.log-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 10px 22px;
+  flex-wrap: wrap;
+  margin-top: 14px;
+  padding: 10px 14px;
+  background: var(--panel-bg);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  box-shadow: var(--shadow-card);
 }
 
-/* The download acts on the log and sits under it, in the middle, rather than in
-   the menu bar where it was a page action among navigation. */
-.log-actions {
+.log-field {
   display: flex;
-  justify-content: center;
-  margin-top: 12px;
+  align-items: center;
+  gap: 8px;
+}
+
+.log-field-label {
+  font-size: 0.85em;
+  color: var(--text-muted);
+}
+
+/* The size line and the download, on the right whatever wraps to the left. On
+   a phone the whole group takes a line of its own and the line pushes the
+   button to the edge, so the two stay apart. */
+.log-toolbar-end {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 14px;
+  margin-left: auto;
+  flex: 1 1 auto;
+}
+
+.log-meta {
+  font-size: 0.85em;
+  color: var(--text-muted);
+  font-variant-numeric: tabular-nums;
+}
+
+/* In the toolbar the picker is one control among others, so it gets the frame
+   and the surface every other button here has instead of the dotted line the
+   dashboard headline uses, and its menu opens under its left edge. */
+.log-toolbar .title-pick {
+  background: var(--control-bg);
+  border-color: var(--border-control);
+  border-radius: 6px;
+  padding: 5px 12px;
+  font-size: 0.88em;
+  font-weight: 400;
+  min-width: 150px;
+  justify-content: space-between;
+  transition: background-color 0.2s, border-color 0.2s;
+}
+
+.log-toolbar .title-pick > span { text-decoration-line: none; }
+.log-toolbar .title-pick.menu-caret::after { font-size: 1em; }
+.log-toolbar .title-pick-plain { padding: 5px 12px; cursor: default; }
+.log-toolbar .title-pick-plain:hover { background: var(--control-bg); }
+
+.log-toolbar .title-panel {
+  left: 0;
+  transform: none;
+}
+
+/* Two buttons welded into one control, the pressed one filled. Two states of
+   one thing rather than two actions, which is why it is not two buttons with
+   a gap between them. */
+.log-switch {
+  display: inline-flex;
+  border: 1px solid var(--border-control);
+  border-radius: 6px;
+  overflow: hidden;
+}
+
+.log-switch button {
+  background: var(--control-bg);
+  color: var(--text);
+  border: none;
+  border-right: 1px solid var(--border-control);
+  padding: 6px 14px;
+  font-size: 0.88em;
+  cursor: pointer;
+  transition: background-color 0.2s;
+}
+
+.log-switch button:last-child { border-right: none; }
+.log-switch button:hover { background: var(--control-hover-bg); }
+
+.log-switch button[aria-pressed="true"] {
+  background: var(--accent-bg);
+  color: #fff;
+  cursor: default;
+}
+
+.log-switch button:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
+}
+
+/* The name of what the box shows and the file it comes from. Left, under the
+   toolbar, because the toolbar is where the eye already is. */
+.log-title {
+  display: flex;
+  align-items: baseline;
+  gap: 12px;
+  flex-wrap: wrap;
+  margin: 14px 0 0;
+}
+
+.log-file {
+  font-family: monospace;
+  font-size: 0.78em;
+  font-weight: 400;
+  color: var(--text-muted);
 }
 
 /* The log page is a column the height of the window: the box takes what is left
-   after the bar, the headline and the button, so the button is on screen
-   whatever the log contains and however long the headline wraps. A fixed
+   after the bar, the toolbar and the title, so the whole box is on screen
+   whatever the log contains and however far the toolbar wraps. A fixed
    max-height had to guess all three. */
 body.logs-page {
   display: flex;
@@ -1208,15 +1320,6 @@ body.logs-page .log-page { width: 100%; }
 .title-pick-plain > span { text-decoration-line: none; }
 .title-pick-plain:hover { background: none; }
 
-/* The serial of the printer whose log this is. Next to the name rather than
-   inside it, so what you click is the name alone. */
-.title-note {
-  font-size: 0.72em;
-  font-weight: 400;
-  color: var(--text-muted);
-  white-space: nowrap;
-}
-
 /* Centred under the headline it belongs to, rather than under its left edge. */
 .title-panel {
   left: 50%;
@@ -1336,6 +1439,15 @@ body.logs-page .log-page { width: 100%; }
 }
 
 .log-button:hover { background: var(--control-hover-bg); }
+
+/* Nothing to hand out yet: the button stays where it is, so the toolbar does
+   not jump, and says so by fading rather than by disappearing. */
+.log-button:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+.log-button:disabled:hover { background: var(--control-bg); }
 
 
 

--- a/src/routes.js
+++ b/src/routes.js
@@ -8,7 +8,7 @@ import { ENV_CONFIG_NOTICE, deprecatedConfig } from "./deprecation.js";
 import { buildDiagnosticsBundle, parseDiagnosticsScope, knownValues, systemInfo } from "./diagnostics.js";
 import { checkForUpdate } from "./update.js";
 import { maskCodes, maskSerial, maskText } from "./anonymize.js";
-import { addPrinter, updatePrinter, updatePrinterLogDetail, removePrinter, syncPrinterIntervals } from "./printers.js";
+import { addPrinter, updatePrinter, updatePrinterLogDetail, removePrinter, syncPrinterIntervals, traceEnabled } from "./printers.js";
 import { restartSpoolmanConnection, restartService } from "./service.js";
 import { state } from "./state.js";
 import { attemptLogin, authEnabled, clearSessionCookie, isAuthenticated, issueSession, setSessionCookie } from "./auth.js";
@@ -363,7 +363,12 @@ export function registerRoutes(app, printers) {
     // Reads across the rotated files, so the requested number of lines is
     // delivered even right after a rotation, when the current file is nearly
     // empty. "files" is what the download button needs to know whether it is
-    // handing out one file or an archive.
+    // handing out one file or an archive; "bytes" is the size of all of them
+    // together, which is what the page says next to it, because a trace grows
+    // by about 22 MB an hour and the number is what tells a reader whether a
+    // download is worth waiting for. "capturing" says whether the trace is
+    // being written at all: a trace that stays empty because the capture is
+    // off reads the same as one that is empty because nothing arrived yet.
     app.get("/api/logs/:printerId", async (req, res) => {
         try {
             const limitRaw = req.query.limit;
@@ -372,10 +377,12 @@ export function registerRoutes(app, printers) {
             const wantsTrace = req.query.stream === "mqtt";
 
             let filePath = serverLogFilePath;
+            let capturing = true;
             if (req.params.printerId !== "server") {
                 const printer = resolvePrinter(req.params.printerId, printers, res);
                 if (!printer) return;
                 filePath = wantsTrace ? printer.traceFilePath : printer.logFilePath;
+                if (wantsTrace) capturing = traceEnabled(printer);
             } else if (wantsTrace) {
                 // There is no server trace: the raw messages belong to a printer
                 return res.status(404).json({ error: "The server has no MQTT trace" });
@@ -385,7 +392,14 @@ export function registerRoutes(app, printers) {
                 tailLogLines(filePath, limit),
                 logFileSet(filePath),
             ]);
-            return res.json({ logs: lines, files: files.length });
+            const sizes = await Promise.all(files.map(file => fsp.stat(file).then(info => info.size, () => 0)));
+            return res.json({
+                logs: lines,
+                files: files.length,
+                bytes: sizes.reduce((sum, size) => sum + size, 0),
+                file: path.basename(filePath),
+                capturing,
+            });
         } catch (err) {
             console.error("Server", serverLogFilePath, `Failed to read log file: ${err.message}`);
             return res.status(500).json({ error: "Failed to read log file" });

--- a/test/routes.logdetail.test.js
+++ b/test/routes.logdetail.test.js
@@ -97,6 +97,11 @@ test("the trace is read through the log route as a stream of its own", async () 
     assert.match(trace.body.logs[0], /gcode_state/);
     // The two files are separate: the ordinary log never carries the reports
     assert.equal(log.body.logs.some(line => line.includes("gcode_state")), false);
+    // The page says the file name, and whether the capture is writing it: this
+    // printer has no override and the global switch is off in the tests
+    assert.equal(trace.body.file, `${SERIAL}.mqtt.log`);
+    assert.equal(trace.body.capturing, false);
+    assert.equal(log.body.capturing, true);
 });
 
 test("the server has no trace to ask for", async () => {

--- a/test/routes.test.js
+++ b/test/routes.test.js
@@ -169,6 +169,10 @@ test("the log endpoint reads across the rotated files", async () => {
     assert.equal(status, 200);
     assert.deepEqual(body.logs, ["older line", "current line"]);
     assert.equal(body.files, 2);
+    // The size covers the rotated file too, because the download does
+    assert.equal(body.bytes, "older line\n".length + "current line\n".length);
+    assert.equal(body.file, "server.log");
+    assert.equal(body.capturing, true);
 });
 
 test("the download is a zip once there is a history, and a log file before that", async () => {


### PR DESCRIPTION
## What

The Logs page gets a toolbar above the log instead of a picker hidden in the headline.

- **Source** is a framed button over the server log and the printers, with the serial next to each printer in the list.
- **Show** is a Log / Raw MQTT trace switch for a printer. It changes the file in place, writes `stream=mqtt` into the address so a link to a trace still opens the trace, and is kept when another printer is picked.
- Next to the download a line says what the page shows and what the download would carry: `refreshes every 5 s · 2 files, 1.3 MB` for a log, `last 50 reports · refreshes every 5 s · 3 files, 41 MB` for a trace, `capture disabled` in front when the printer's trace is not being written. An empty trace box then says where to enable it.
- The title under the toolbar names the file on disk, which is what a bug report ends up naming.
- `GET /api/logs/:id` answers `bytes`, `file` and `capturing` next to the lines and the file count.

## Why

The reporter of #131 did not find the raw MQTT trace: "Backend Logs for: P1S" was the picker, with a dotted underline and a small caret, and the trace was a group inside its menu. A choice has to look like a control.

## Verified

- Mock printer (`scripts/test-server`): server log, printer log, trace disabled and enabled, light and dark, 375 px wide without horizontal scrolling.
- Real P2S against the throwaway Spoolman, manual mode: trace disabled shows the hint and a greyed download; enabled through the log detail override, reports arrive, size line grows (91 KB after 15 s), download dialog opens as "Download the raw MQTT trace", switching back to Log drops the query parameter.
- `node --test`: 572 pass, 2 todo (the known A2L gap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)