### PR TITLE
chore: bump the version to 1.3.0-dev.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 -----------------------------------------------------------------------------------------------
-Unreleased
+Version 1.3.0-dev.16
    - Features:
       - The Logs page carries its choices as controls, not as a heading. The name in "Backend Logs for: P1S" was the picker over the logs, and a printer's raw MQTT trace was a group inside its menu; the first person who needed a trace did not find it there (issue #131). A toolbar above the log now holds a Source button over the server and the printers, a Log / Raw MQTT trace switch for a printer, and the download
          - Next to the download the page says what it shows and what the download would carry: "refreshes every 5 s · 2 files, 1.3 MB" for a log, "last 50 reports · refreshes every 5 s · 3 files, 41 MB" for a trace, and "capture disabled" in front when the trace of that printer is not being written. The box then says where to enable it rather than showing an empty file

--- a/docs/changelog-1.3.0-draft.md
+++ b/docs/changelog-1.3.0-draft.md
@@ -6,7 +6,7 @@ between two builds. This file is the consolidated release block, written into
 CHANGELOG.md in place of those dev blocks when the release build is cut, not
 before.
 
-Every dev build after dev.15 has to be folded in here as well, or regenerate the
+Every dev build after dev.16 has to be folded in here as well, or regenerate the
 whole block from the dev blocks at release time.
 
 ## Draft
@@ -58,6 +58,7 @@ Version 1.3.0
          - Errors and the ordinary progress lines are never filtered by area, so switching one off cannot hide a failure
       - Every MQTT message a printer sends can be captured into logs/<serial>.mqtt.log, one line per message, with its own size and history budget. It is what the printer really sent rather than what this service made of it, and it is every kind of message, not only the status reports this service reads: a P2S print produced seven, of which one is looked at anywhere. Measured on a P2S it runs at about 22 MB an hour, idle and under a print alike. Readable and downloadable like any other log and part of the diagnostics archive
       - Every printer can have log settings of its own, "Log" next to it in the Printers card, so one machine can run at trace with its capture going while the rest of the service stays quiet
+      - The Logs page carries its choices as controls: a Source button over the server and the printers, a Log / Raw MQTT trace switch for a printer, and the download next to a line saying what the page shows and what the download would carry, "last 50 reports · refreshes every 5 s · 3 files, 41 MB" for a trace and "capture disabled" in front when that printer's trace is not being written. The title names the file on disk, which is what a bug report ends up naming
       - The print path says what it is doing at debug level, which it never did before: the FTPS fetch names the paths it looks for and which one answered, and the booking names every state change, which consumption sum ran and on what layer, where the slots came from, and what the matcher answered per filament
       - A clean print does not inherit the failure of the one before it. A P2S keeps repeating its previous complaint for a report or two after a new print has started, so the summary of a FINISH could say the print had failed
       - Connection test for Spoolman and for a printer, MQTT and FTPS, against the values in the form

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bambulab-ams-spoolman-filamentstatus",
-  "version": "1.3.0-dev.15",
+  "version": "1.3.0-dev.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bambulab-ams-spoolman-filamentstatus",
-      "version": "1.3.0-dev.15",
+      "version": "1.3.0-dev.16",
       "license": "ISC",
       "dependencies": {
         "adm-zip": "^0.6.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "mqtt": "^5.15.2"
   },
   "name": "bambulab-ams-spoolman-filamentstatus",
-  "version": "1.3.0-dev.15",
+  "version": "1.3.0-dev.16",
   "main": "app.js",
   "type": "module",
   "engines": {

--- a/src/config.js
+++ b/src/config.js
@@ -32,7 +32,7 @@ export const apiKeysPath = path.join(dataDir, "apikeys.json");
 // brings the service back on its own or depends on the container policy.
 export const supervised = process.env.SUPERVISED === "1";
 
-export const version = "1.3.0-dev.15";
+export const version = "1.3.0-dev.16";
 export const PORT = 4000;
 
 /** The spellings a boolean environment variable is accepted in. */


### PR DESCRIPTION
Bumps to 1.3.0-dev.16 after #143 (the Logs page toolbar).

- `package.json`, `package-lock.json`, `src/config.js`
- The Unreleased block of CHANGELOG.md becomes Version 1.3.0-dev.16
- The 1.3.0 draft carries the Logs page entry under New Features and its fold-in note moves to dev.16

`node --test`: 572 pass, 2 todo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)