### PR TITLE
fix: a print sent through the Bambu cloud is booked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Unreleased
          - Next to the download the page says what it shows and what the download would carry: "refreshes every 5 s · 2 files, 1.3 MB" for a log, "last 50 reports · refreshes every 5 s · 3 files, 41 MB" for a trace, and "capture disabled" in front when the trace of that printer is not being written. The box then says where to enable it rather than showing an empty file
          - The switch changes the file in place and writes it into the address, so a link to a trace still opens the trace, and picking another printer while reading traces opens that printer's trace. The title under the toolbar names the file on disk, which is what a bug report ends up naming
          - The log endpoint answers the size of the file set, the file name and whether the capture is on, next to the line count it already answered
+   - Fixes:
+      - A print sent through the Bambu cloud, from Bambu Studio or the Handy app, is booked. The printer keeps such a file as "<job>.3mf" and says so in its report, while this service only ever asked for "<job>.gcode.3mf", the name a file sent over the LAN gets, so every cloud print ended with "slice_info.config not found" and nothing booked. Read off a P1S whose seven cloud prints since 6 September 2026 all went that way (issue #146). The name the printer reports is now tried first, then both spellings
+         - A file that is not found is not looked for again every few seconds: the dashboard asks for the print's figures on every refresh, and each ask was one FTPS login to the printer for the whole print, 303 of them in fifteen minutes on that P1S. One search per print now, the manual ?job= test aside
+         - The log says which of the two it was: no file on the printer under the names tried, or a file that carries no slice_info.config. Both used to read the same
 
 -----------------------------------------------------------------------------------------------
 Version 1.3.0-dev.15

--- a/src/gcode.js
+++ b/src/gcode.js
@@ -21,22 +21,32 @@ export function bambuTlsOptions() {
 }
 
 /**
- * Downloads the .gcode.3mf for the active print via FTPS and extracts only
+ * Downloads the sliced 3MF of the active print via FTPS and extracts only
  * Metadata/slice_info.config (~2-3 KB). The rest of the archive is discarded
  * immediately after extraction.
  *
  * BambuLab printers run vsftpd with implicit TLS on port 990, login bblp /
- * <access code>. The actual sliced files live in /cache/<job>.gcode.3mf. The
- * MQTT `gcode_file` field (e.g. /data/Metadata/plate_1.gcode) is an internal
- * path that is NOT exposed over FTP, so we resolve via the job name instead.
+ * <access code>. The sliced file lives in /cache, under the name the job was
+ * sent with; see `resolveRemotePaths()` for the two spellings of that name.
+ *
+ * What was tried and what came of it is written to `printer.lastSliceFetch`,
+ * because the two ways this returns null are two different problems for the
+ * person reading the log: no file under any of the names, or a file that is
+ * not a sliced one. The callers log from that record, and `/api/print` reads
+ * it to not try the same names again every few seconds for the whole print.
  *
  * @param {object} printer  - printer object with .ip and .code
- * @param {string} jobName  - subtask_name / gcode_file from MQTT
+ * @param {string} jobName  - subtask_name from MQTT
+ * @param {string|null} [gcodeFile] - gcode_file from MQTT, when the report carries one
  * @returns {object|null} parsed slice info or null if not found
  */
-export async function fetchSliceInfo(printer, jobName) {
+export async function fetchSliceInfo(printer, jobName, gcodeFile = null) {
     const client = new ftp.Client(20000); // 20 s timeout
     client.ftp.verbose = false;
+
+    const candidates = resolveRemotePaths(jobName, gcodeFile);
+    const record = { jobName, tried: candidates, path: null, sliceInfo: false, at: Date.now() };
+    printer.lastSliceFetch = record;
 
     try {
         await client.access({
@@ -48,7 +58,6 @@ export async function fetchSliceInfo(printer, jobName) {
             secureOptions: bambuTlsOptions(),
         });
 
-        const candidates = resolveRemotePaths(jobName);
         debug("gcode", printer.name, printer.logFilePath,
             `[Print] Looking for the sliced file as ${candidates.join(" or ")}`);
 
@@ -61,6 +70,7 @@ export async function fetchSliceInfo(printer, jobName) {
                 });
                 await client.downloadTo(writable, path);
                 buf = Buffer.concat(chunks);
+                record.path = path;
                 debug("gcode", printer.name, printer.logFilePath,
                     `[Print] Downloaded ${path}, ${buf.length} bytes`);
                 break;
@@ -109,6 +119,7 @@ export async function fetchSliceInfo(printer, jobName) {
             entry.getData().toString("utf8"),
             settings ? settings.getData().toString("utf8") : null,
         );
+        record.sliceInfo = true;
 
         trace("gcode", printer.name, printer.logFilePath,
             `[Print] Parsed slice info: ${JSON.stringify(parsed)}`);
@@ -405,26 +416,42 @@ export function calcPartialConsumption(sliceInfo, upToLayer) {
 // ---------------------------------------------------------------------------
 
 /**
- * Builds candidate FTPS paths for the sliced 3MF from a MQTT job name.
+ * The FTPS paths the sliced 3MF of a job may sit under, most likely first.
  *
- * gcode_file from MQTT can be:
- *   /data/Metadata/plate_1.gcode  (internal path, strip to base name)
- *   My Print.gcode.3mf
- *   My Print
- * The real file is /cache/<name>.gcode.3mf, sometimes also in the FTP root.
+ * The file is named after the job, but the extension depends on how the job
+ * reached the printer, and the printer says which in `gcode_file`:
+ *
+ *   - sent from the slicer over the LAN, it is `<job>.gcode.3mf`, which is the
+ *     name "Export sliced file" gives it. Read off a P2S, a P1S and an X1E
+ *   - sent through the Bambu cloud, from Bambu Studio or the Handy app, it is
+ *     `<job>.3mf`. Read off a P1S whose seven cloud prints of September 2026
+ *     all reported `gcode_file` "<job>.3mf" and answered 550 for the
+ *     `.gcode.3mf` spelling, so not one of them was ever booked (issue #146)
+ *   - `gcode_file` can also be the printer's internal `/data/Metadata/plate_1.gcode`,
+ *     seen on the X1E, which names no file at all and is ignored
+ *
+ * So the name the printer reports comes first when it names a 3MF, then both
+ * spellings under /cache, then both in the FTP root, where older firmware was
+ * seen to keep the file.
+ *
+ * @param {string} jobName - `subtask_name` from MQTT
+ * @param {string|null} [gcodeFile] - `gcode_file` from MQTT
+ * @returns {string[]} candidate paths, without duplicates
  */
-function resolveRemotePaths(jobName) {
-    if (!jobName) return [];
+export function resolveRemotePaths(jobName, gcodeFile = null) {
+    const candidates = [];
 
-    // Internal /data/Metadata/plate_1.gcode path carries no job name → useless;
-    // caller should pass subtask_name in that case. Strip directory anyway.
-    let name = jobName.split("/").pop();
+    const reported = typeof gcodeFile === "string" ? gcodeFile.split("/").pop() : "";
+    if (/\.3mf$/i.test(reported)) candidates.push(`/cache/${reported}`);
 
-    // Normalise to the bare job name without extensions
-    name = name.replace(/\.gcode\.3mf$/i, "").replace(/\.3mf$/i, "").replace(/\.gcode$/i, "");
+    if (jobName) {
+        // Normalise to the bare job name without extensions, whichever it came with
+        const name = jobName.split("/").pop()
+            .replace(/\.gcode\.3mf$/i, "").replace(/\.3mf$/i, "").replace(/\.gcode$/i, "");
+        candidates.push(`/cache/${name}.gcode.3mf`, `/cache/${name}.3mf`, `/${name}.gcode.3mf`, `/${name}.3mf`);
+    }
 
-    const file = `${name}.gcode.3mf`;
-    return [`/cache/${file}`, `/${file}`];
+    return [...new Set(candidates)];
 }
 
 /**

--- a/src/mqtt.js
+++ b/src/mqtt.js
@@ -101,6 +101,24 @@ function broadcastAmsEnvironment(printer, amsUnits, now) {
     broadcastSSE({ type: "ams_env", printer: printer.id, amsEnv });
 }
 
+/**
+ * Why the last slice info fetch came back empty, for the log.
+ *
+ * Two different problems used to share one sentence, "slice_info.config not
+ * found in 3MF", and the one that was actually happening, no file under that
+ * name at all, was the one the sentence did not say.
+ *
+ * @param {object|null} record - `printer.lastSliceFetch`
+ * @returns {string} one clause, without a full stop
+ */
+export function sliceFetchFailure(record) {
+    if (!record) return "No sliced file was fetched";
+    if (!record.path) {
+        return `No sliced file on the printer under ${record.tried.join(", ")}`;
+    }
+    return `${record.path} carries no Metadata/slice_info.config`;
+}
+
 // Print states that signal the end of a print job
 const TERMINAL_STATES = new Set(["FINISH", "FAILED", "CANCEL"]);
 // Print states that indicate an active or paused job. Built from the list in
@@ -158,7 +176,9 @@ export async function handlePrintStateChange(printer, print) {
     const freshStart = ACTIVE_STATES.has(newState) && !ACTIVE_STATES.has(prevState);
     if (freshStart) {
         printer.currentJobName    = jobName;
+        printer.currentGcodeFile  = print.gcode_file || null;
         printer.currentSliceInfo  = null;
+        printer.lastSliceFetch    = null;
         printer.currentMapping    = null;
         printer.consumptionBooked = false;
         printer.sliceFetchDone    = false;
@@ -216,7 +236,12 @@ export async function handlePrintStateChange(printer, print) {
         }
     }
 
-    // Fetch slice info once we reach RUNNING (the .gcode.3mf is reliably present
+    // The file name the printer reports for the job, which says whether the
+    // sliced file is a .3mf (cloud) or a .gcode.3mf (LAN). Read on every report
+    // like the job name: it can arrive a report or two after the state does.
+    if (print.gcode_file) printer.currentGcodeFile = print.gcode_file;
+
+    // Fetch slice info once we reach RUNNING (the sliced file is reliably present
     // in /cache by then). Guarded so we only attempt it once per print.
     if (newState === "RUNNING" && jobName && !printer.sliceFetchDone) {
         printer.sliceFetchDone = true;
@@ -224,11 +249,11 @@ export async function handlePrintStateChange(printer, print) {
 
         console.log(printer.name, printer.logFilePath, `[Print] Print running: "${jobName}", fetching slice info via FTPS...`);
         try {
-            printer.currentSliceInfo = await fetchSliceInfo(printer, jobName);
+            printer.currentSliceInfo = await fetchSliceInfo(printer, jobName, printer.currentGcodeFile);
             if (printer.currentSliceInfo) {
                 console.log(printer.name, printer.logFilePath, `[Print] Slice info loaded: ${printer.currentSliceInfo.filaments.length} filament(s), ${printer.currentSliceInfo.totalLayers} layers`);
             } else {
-                console.log(printer.name, printer.logFilePath, "[Print] slice_info.config not found in 3MF, consumption tracking unavailable for this print");
+                console.log(printer.name, printer.logFilePath, `[Print] ${sliceFetchFailure(printer.lastSliceFetch)}, consumption tracking unavailable for this print`);
             }
         } catch (err) {
             console.error(printer.name, printer.logFilePath, `[Print] Could not fetch slice info: ${err.message}`);

--- a/src/routes.js
+++ b/src/routes.js
@@ -617,11 +617,18 @@ export function registerRoutes(app, printers) {
         const layerNum  = cleared ? 0 : (printer.currentLayerNum || 0);
 
         // Fetch fresh slice info if a job is known (or explicitly requested),
-        // otherwise fall back to the cached version
+        // otherwise fall back to the cached version.
+        //
+        // Not again for a job the print handler already looked for and did not
+        // find: the dashboard asks every few seconds, and a job whose file is
+        // not there would otherwise cost one FTPS login per request for the
+        // whole print. Measured on a P1S: 303 logins in fifteen minutes. The
+        // manual ?job= test is the exception, it asks for exactly that.
         let sliceInfo = req.query.job || cleared ? null : (printer.currentSliceInfo || null);
-        if (jobName && !sliceInfo) {
+        const alreadyLookedFor = !req.query.job && printer.lastSliceFetch?.jobName === jobName;
+        if (jobName && !sliceInfo && !alreadyLookedFor) {
             try {
-                sliceInfo = await fetchSliceInfo(printer, jobName);
+                sliceInfo = await fetchSliceInfo(printer, jobName, req.query.job ? null : printer.currentGcodeFile);
             } catch (err) {
                 // non-fatal, surface the error in the response
                 return res.json({

--- a/test/gcode.remotepaths.test.js
+++ b/test/gcode.remotepaths.test.js
@@ -1,0 +1,64 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { resolveRemotePaths } from "../src/gcode.js";
+import { sliceFetchFailure } from "../src/mqtt.js";
+
+// Where the sliced file sits depends on how the job reached the printer, and
+// the printer says which in gcode_file. Every name below is one a real printer
+// reported in September 2026 through issue #146.
+
+test("a cloud print is looked for under the name the printer reports, .3mf first", () => {
+    // Schnuecks's P1S, seven cloud prints, every one of them gcode_file "<job>.3mf"
+    // and never found under the .gcode.3mf spelling
+    assert.deepEqual(resolveRemotePaths("Würfel", "Würfel.3mf"), [
+        "/cache/Würfel.3mf",
+        "/cache/Würfel.gcode.3mf",
+        "/Würfel.gcode.3mf",
+        "/Würfel.3mf",
+    ]);
+
+    const long = "Resqme Sunvisor Mount - 0.2mm layer, 2 walls, 15% infill";
+    assert.equal(resolveRemotePaths(long, `${long}.3mf`)[0], `/cache/${long}.3mf`);
+});
+
+test("a LAN print is looked for under .gcode.3mf first, as before", () => {
+    // beegee-tokyo's P1S, sent from OrcaSlicer over the LAN
+    assert.deepEqual(resolveRemotePaths("BambuLab-AMS-Spoolman-Testprint_v2", "BambuLab-AMS-Spoolman-Testprint_v2.gcode.3mf"), [
+        "/cache/BambuLab-AMS-Spoolman-Testprint_v2.gcode.3mf",
+        "/cache/BambuLab-AMS-Spoolman-Testprint_v2.3mf",
+        "/BambuLab-AMS-Spoolman-Testprint_v2.gcode.3mf",
+        "/BambuLab-AMS-Spoolman-Testprint_v2.3mf",
+    ]);
+});
+
+test("the printer's internal gcode path names no file and is ignored", () => {
+    // The X1E reports /data/Metadata/plate_1.gcode for the whole print
+    assert.deepEqual(resolveRemotePaths("Würfel", "/data/Metadata/plate_1.gcode"), [
+        "/cache/Würfel.gcode.3mf",
+        "/cache/Würfel.3mf",
+        "/Würfel.gcode.3mf",
+        "/Würfel.3mf",
+    ]);
+    assert.deepEqual(resolveRemotePaths("Würfel"), resolveRemotePaths("Würfel", null));
+});
+
+test("a job name that already carries an extension is not doubled", () => {
+    assert.equal(resolveRemotePaths("My Print.gcode.3mf")[0], "/cache/My Print.gcode.3mf");
+    assert.equal(resolveRemotePaths("My Print.3mf")[0], "/cache/My Print.gcode.3mf");
+    assert.equal(resolveRemotePaths("/data/My Print.gcode")[0], "/cache/My Print.gcode.3mf");
+    assert.deepEqual(resolveRemotePaths(""), []);
+    assert.deepEqual(resolveRemotePaths(null, "Würfel.3mf"), ["/cache/Würfel.3mf"]);
+});
+
+test("the log names the problem it actually had", () => {
+    assert.equal(sliceFetchFailure(null), "No sliced file was fetched");
+    assert.equal(
+        sliceFetchFailure({ jobName: "Würfel", tried: ["/cache/Würfel.3mf", "/cache/Würfel.gcode.3mf"], path: null }),
+        "No sliced file on the printer under /cache/Würfel.3mf, /cache/Würfel.gcode.3mf",
+    );
+    assert.equal(
+        sliceFetchFailure({ jobName: "Würfel", tried: ["/cache/Würfel.3mf"], path: "/cache/Würfel.3mf", sliceInfo: false }),
+        "/cache/Würfel.3mf carries no Metadata/slice_info.config",
+    );
+});

--- a/test/routes.print.test.js
+++ b/test/routes.print.test.js
@@ -172,3 +172,22 @@ test("an unassigned 3rd party slot still shows what the print needs from it", as
     assert.equal(matched.length, 1);
     assert.equal(matched[0].color.replace("#", "").toUpperCase(), f1.color.toUpperCase());
 });
+
+test("a file the print handler did not find is not looked for again on every refresh", async () => {
+    // What the MQTT handler leaves behind after a fetch that found nothing.
+    // Without the guard the route would open an FTPS connection to 127.0.0.1
+    // on every call, which is one login per dashboard refresh for the whole
+    // print; with it the answer is the same empty one, at once.
+    printer.currentSliceInfo = null;
+    printer.lastSliceFetch = { jobName: "four colours", tried: ["/cache/four colours.3mf"], path: null, sliceInfo: false, at: Date.now() };
+
+    const started = Date.now();
+    const { status, body } = await call(`${app.url}/api/print/${SERIAL}`);
+    assert.equal(status, 200);
+    assert.equal(body.sliceInfo, null);
+    assert.equal(body.error, undefined);
+    assert.ok(Date.now() - started < 2000, "answered without an FTPS attempt");
+
+    printer.currentSliceInfo = sliceInfo;
+    printer.lastSliceFetch = null;
+});


### PR DESCRIPTION
## What

A print sent through the Bambu cloud, from Bambu Studio or the Handy app, was never booked. The printer keeps such a file as `<job>.3mf` and says so in `gcode_file`, while this service only ever asked for `<job>.gcode.3mf`, the name a file sent over the LAN gets. Every cloud print ended with "slice_info.config not found in 3MF" and nothing was booked.

- `resolveRemotePaths(jobName, gcodeFile)` in `src/gcode.js` tries the name the printer reports first when it ends in `.3mf`, then `/cache/<job>.gcode.3mf`, `/cache/<job>.3mf`, and both spellings in the FTP root. The printer's internal `/data/Metadata/plate_1.gcode` names no file and is ignored.
- One search per print. `printer.lastSliceFetch` keeps the names tried and what came of it, and `/api/print` no longer downloads again for a job the print handler already looked for. The dashboard asks every few seconds, and each ask was one FTPS login to the printer for the whole print. The manual `?job=` test still fetches.
- The log says which of the two it was: "No sliced file on the printer under /cache/Würfel.3mf, ..." or "/cache/x.3mf carries no Metadata/slice_info.config". Both used to read the same sentence, and the one that was happening was the one it did not say.

## Why now

Read off the P1S diagnostics in issue #146 on 2026-09-07: all seven prints since 6 September reported `gcode_file: "<job>.3mf"`, the `.gcode.3mf` spelling answered 550 on both paths, and the dashboard's polling produced 303 FTPS logins in fifteen minutes during one print. The LAN prints of the other two testers, a P1S from OrcaSlicer and an X1E from Bambu Studio, report `<job>.gcode.3mf` and were booked, which is why nobody here had seen it. Likely part of issue #59.

## Verified

- `node --test`: 583 tests, 581 pass, 2 todo (the known A2L unit 16 gaps). `test/gcode.remotepaths.test.js` carries the three real names, `test/routes.print.test.js` the guard.
- Not verified against a real cloud print: nobody here prints through the cloud. The next print on that P1S with this build is the proof, and its log then shows the booking and the slot estimate together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
