### PR TITLE
feat: the create dialog proposes the filament from the slot's preset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,13 @@
 -----------------------------------------------------------------------------------------------
+Unreleased
+   - Features:
+      - The create dialog of a chipless slot proposes the filament from the slot's preset (issue #47). A vendor preset chosen in Bambu Studio, "SUNLU PETG" or "PolyLite PETG", names the manufacturer, so the catalogue is narrowed to that maker and the slot's material when the dialog opens, and the entry nearest the slot's colour is filled in as a proposal, with a line saying how near: "High Speed Matte PETG - Black, the nearest colour in the catalogue (151616 for the slot's 161616)". Nothing is created by itself; the proposal is what the form starts with
+         - The colour the slot reports is what somebody picked on the printer's screen, from a fixed palette, or typed in Bambu Studio, so it rarely equals the catalogue's value and the nearest one is proposed rather than an exact one demanded. An AMS takes a spool of up to 1 kg, so for a slot inside one a filament sold on a heavier spool is ranked behind every fitting one; the external holder takes any size
+         - The manufacturer is spelled the way this Spoolman or the catalogue already spells it, so "SUNLU" from the preset does not create a second vendor next to "Sunlu". A Bambu, a generic or a custom preset names no manufacturer, and the dialog then starts as before, with the material and the colours
+         - The material field starts with the preset's material where the preset is known, "PLA-CF" rather than the "PLA" the AMS reports next to it
+         - Read off an X1E on 2026-09-08 whose holder carried SUNLU PETG and PolyLite PETG chosen in Bambu Studio, arriving as GFSNL08 and GFG60
+
+-----------------------------------------------------------------------------------------------
 Version 1.3.0-dev.16
    - Features:
       - A 3rd party spool can be assigned without asking, where there is nothing to ask (issue #47). "Assign 3rd party spools automatically" in the Tracking settings, off by default, links a spool without an RFID tag to the one Spoolman spool of the same material and colours that carries no tag and sits in no other slot. The slot then reads "auto-assigned", consumption is booked onto that spool, and the assignment is dropped like a manual one when a different filament shows up in the slot

--- a/public/frontend.js
+++ b/public/frontend.js
@@ -15,8 +15,8 @@ import {
     slotColors,
     spoolWeightLimit,
 } from "./shared.js";
-import { bambuProfile, materialsAgree, slotMaterial, slotPreset } from "./materials.js";
-import { colorSetDistance, uniqueSpoolForSlot } from "./match.js";
+import { bambuProfile, materialsAgree, presetVendor, slotMaterial, slotPreset } from "./materials.js";
+import { catalogueColors, colorSetDistance, rankCatalogueEntries, uniqueSpoolForSlot } from "./match.js";
 import { escapeHtml, fetchJson, sendJson } from "./ui.js";
 
 let autoButton = null;
@@ -836,12 +836,6 @@ document.addEventListener("DOMContentLoaded", () => {
         return String(a ?? "").trim().toLowerCase() === String(b ?? "").trim().toLowerCase();
     }
 
-    /** The colours a catalogue entry carries, in the shape the swatches use. */
-    function catalogueColors(entry) {
-        if (entry.color_hexes?.length) return entry.color_hexes.map(c => normColor(c).toLowerCase());
-        return entry.color_hex ? [normColor(entry.color_hex).toLowerCase()] : [];
-    }
-
     // What each catalogue entry is called in the picker.
     //
     // The name alone, because the two steps above it already said which
@@ -890,12 +884,19 @@ document.addEventListener("DOMContentLoaded", () => {
     //
     // The AMS reports every colour of a multi colour spool, so all of them are
     // offered: taking only `tray_color` created a plain black spool for a
-    // filament that is black and red.
+    // filament that is black and red. The material is the preset's where the
+    // preset is a known one, "PLA-CF" rather than the "PLA" the AMS reports
+    // next to it, and a vendor preset names the manufacturer as well.
     function slotDefaults(slot) {
         const colors = slotColors(slot).map(c => normColor(c));
+        const preset = slotPreset(slot);
+        const vendor = presetVendor(preset);
         return {
-            material: slot.tray_type || "",
+            material: slotMaterial(slot) || "",
             colors: colors.length ? colors : [normColor(slot.tray_color) || "000000"],
+            vendor: vendor?.vendor ?? "",
+            line: vendor?.line ?? null,
+            presetName: preset?.name ?? null,
         };
     }
 
@@ -923,6 +924,13 @@ document.addEventListener("DOMContentLoaded", () => {
             .map(f => `<option value="${f.id}">#${f.id} ${escapeHtml([f.vendor?.name, f.material, f.name].filter(Boolean).join(" · "))}</option>`)
             .join("");
 
+        // The manufacturer the preset names, spelled the way this Spoolman or
+        // the catalogue already spells it, so the vendor step narrows the
+        // catalogue and the vendor field does not create "Sunlu" next to "SUNLU".
+        const vendorSpelling = defaults.vendor
+            ? (vendors.find(v => sameText(v, defaults.vendor)) ?? defaults.vendor)
+            : "";
+
         pane.innerHTML = `
             <div class="sp-scroll">
                 <div class="sp-section">Filament</div>
@@ -940,7 +948,8 @@ document.addEventListener("DOMContentLoaded", () => {
                         <div class="sp-catalogue-steps">
                             <label class="sp-field">
                                 <span>1. Manufacturer</span>
-                                <input id="sp-cat-vendor" list="sp-cat-vendors" autocomplete="off" placeholder="all manufacturers">
+                                <input id="sp-cat-vendor" list="sp-cat-vendors" autocomplete="off" placeholder="all manufacturers"
+                                    value="${escapeHtml(vendorSpelling)}">
                                 <datalist id="sp-cat-vendors">${(lookups.externalVendors || []).map(v => `<option value="${escapeHtml(v)}">`).join("")}</datalist>
                             </label>
                             <label class="sp-field">
@@ -961,7 +970,7 @@ document.addEventListener("DOMContentLoaded", () => {
                     <div class="sp-subsection">Filament data</div>
                     <label class="sp-field">
                         <span>Manufacturer</span>
-                        <input id="sp-vendor" list="sp-vendors" autocomplete="off" placeholder="e.g. Sunlu">
+                        <input id="sp-vendor" list="sp-vendors" autocomplete="off" placeholder="e.g. Sunlu" value="${escapeHtml(vendorSpelling)}">
                         <datalist id="sp-vendors">${vendors.map(v => `<option value="${escapeHtml(v)}">`).join("")}</datalist>
                         <small class="gc-muted" id="sp-vendor-hint"></small>
                     </label>
@@ -1112,6 +1121,39 @@ document.addEventListener("DOMContentLoaded", () => {
             $("sp-catalogue-hint").textContent = ordered.length
                 ? `${ordered.length}${ordered.length === 500 ? "+" : ""} entries, by name`
                 : "Nothing in the catalogue matches this manufacturer and material";
+
+            suggestFromPreset();
+        };
+
+        // The first list for a slot whose preset names the manufacturer is
+        // narrowed to that maker and this material already, so the entry nearest
+        // the slot's colour is most likely the spool, and it is filled in as a
+        // proposal. Once only, when the dialog opens: after that the steps are
+        // the user's. A generic preset or a custom one names no maker, and the
+        // nearest colour among every maker's filaments would be a guess.
+        let suggested = !defaults.vendor;
+        const suggestFromPreset = () => {
+            if (suggested || !catalogue.size) return;
+            suggested = true;
+
+            const ranked = rankCatalogueEntries([...catalogue.values()], slot, {
+                external: amsSpool.amsId === EXTERNAL_SLOT || amsSpool.amsId === SECOND_EXTERNAL_SLOT,
+                line: defaults.line,
+            });
+            const best = ranked[0];
+            if (!best || best.tooHeavy || !Number.isFinite(best.distance)) return;
+
+            const label = [...catalogue.entries()].find(([, entry]) => entry === best.entry)?.[0];
+            if (!label) return;
+
+            $("sp-cat-filament").value = label;
+            applyCatalogueEntry();
+
+            const slotColours = defaults.colors.join(", ");
+            const catalogueColours = catalogueColors(best.entry).join(", ");
+            $("sp-catalogue-hint").textContent = best.distance === 0
+                ? `Proposed from the slot's preset "${defaults.presetName}": ${best.entry.name}, the same colour. Pick another filament above if it is not this one`
+                : `Proposed from the slot's preset "${defaults.presetName}": ${best.entry.name}, the nearest colour in the catalogue (${catalogueColours} for the slot's ${slotColours}). Pick another filament above if it is not this one`;
         };
 
         // What the catalogue knows about the manufacturer of the picked entry.

--- a/public/match.js
+++ b/public/match.js
@@ -98,3 +98,61 @@ export function uniqueSpoolForSlot(slot, spools, taken = new Set()) {
         spoolIsChipless(spool) && !taken.has(spool.id) && spoolFitsSlot(slot, spool));
     return fitting.length === 1 ? fitting[0] : null;
 }
+
+/**
+ * The colours a SpoolmanDB catalogue entry carries, lower case, without "#".
+ *
+ * @param {object} entry - a catalogue entry as Spoolman serves it
+ * @returns {string[]} every colour, a multi colour filament's whole set
+ */
+export function catalogueColors(entry) {
+    if (entry?.color_hexes?.length) return entry.color_hexes.map(c => normColor(c).toLowerCase());
+    return entry?.color_hex ? [normColor(entry.color_hex).toLowerCase()] : [];
+}
+
+/** What an AMS slot can take: a spool of this weight or less, in grams. */
+export const AMS_SPOOL_LIMIT = 1000;
+
+/**
+ * The catalogue entries that could be the spool in a chipless slot, best first.
+ *
+ * The slot names the manufacturer and the material through its preset, so the
+ * entries are already narrowed to those; what is left is which of a maker's
+ * colours it is. The colour the slot reports is what somebody picked on the
+ * printer's screen, from a fixed palette, or typed in Bambu Studio, so it is
+ * rarely the catalogue's exact value and the nearest one is the answer, with
+ * the distance kept so the dialog can say how near it was.
+ *
+ * Two facts decide before the colour does:
+ *
+ *   - an AMS takes a spool of up to 1 kg, so for a slot inside one an entry
+ *     sold on a heavier spool cannot be the one. The external holder takes any
+ *     size, which is where every 2 kg and 3 kg spool is printed from
+ *   - a preset that names a product line, "PolyLite PETG", is the line, so an
+ *     entry of the same maker and material from another line, "PolyMax PETG",
+ *     ranks behind every entry that carries the word
+ *
+ * @param {object[]} entries - catalogue entries, already narrowed by manufacturer and material
+ * @param {object} slot - the slot as the client payload carries it
+ * @param {object} [options]
+ * @param {boolean} [options.external] - whether the slot is an external holder
+ * @param {string|null} [options.line] - the product line word of the preset
+ * @returns {{entry: object, distance: number, tooHeavy: boolean, offLine: boolean}[]} best first
+ */
+export function rankCatalogueEntries(entries, slot, { external = false, line = null } = {}) {
+    const colors = slotColors(slot).map(c => normColor(c).toLowerCase());
+    const word = line ? line.toLowerCase() : null;
+
+    return (entries || [])
+        .map(entry => ({
+            entry,
+            distance: colorSetDistance(colors, catalogueColors(entry)),
+            tooHeavy: !external && entry.weight != null && Number(entry.weight) > AMS_SPOOL_LIMIT,
+            offLine: !!word && !String(entry.name ?? "").toLowerCase().includes(word),
+        }))
+        .sort((a, b) =>
+            Number(a.tooHeavy) - Number(b.tooHeavy) ||
+            Number(a.offLine) - Number(b.offLine) ||
+            a.distance - b.distance ||
+            String(a.entry.name ?? "").localeCompare(String(b.entry.name ?? "")));
+}

--- a/public/materials.js
+++ b/public/materials.js
@@ -235,6 +235,43 @@ export function slotPreset(slot) {
 }
 
 /**
+ * The manufacturers behind the vendor profiles Bambu Studio ships, keyed by the
+ * word their profile names start with. A product line word names the line as
+ * well, because the catalogue calls the filament by it: SpoolmanDB lists
+ * "PolyLite™ PETG Black" under Polymaker, not under PolyLite.
+ *
+ * The manufacturer names are spelled the way SpoolmanDB spells them, which is
+ * what the create dialog matches them against. The two spellings of Sunlu are
+ * the reason this is a table rather than the first word of the profile name.
+ */
+const PRESET_VENDORS = {
+    SUNLU: { vendor: "Sunlu", line: null },
+    POLYLITE: { vendor: "Polymaker", line: "PolyLite" },
+    POLYTERRA: { vendor: "Polymaker", line: "PolyTerra" },
+    FIBERON: { vendor: "Polymaker", line: "Fiberon" },
+    ESUN: { vendor: "eSUN", line: null },
+    OVERTURE: { vendor: "Overture", line: null },
+};
+
+/**
+ * The manufacturer a slot preset points at, for prefilling the create dialog.
+ *
+ * Only a vendor profile names one: a Bambu profile is Bambu's own filament, a
+ * generic profile and a custom preset (`P` plus seven hex digits) say nothing
+ * about who made the spool. Read off an X1E on 2026-09-08, where SUNLU PETG and
+ * PolyLite PETG chosen in Bambu Studio arrived as GFSNL08 and GFG60.
+ *
+ * @param {object|null} preset - what `slotPreset()` returned
+ * @returns {{vendor: string, line: string|null}|null} the manufacturer as
+ *   SpoolmanDB spells it, and the product line word when the name carries one
+ */
+export function presetVendor(preset) {
+    if (preset?.kind !== "vendor" || !preset.name) return null;
+    const first = preset.name.split(/\s+/)[0].toUpperCase();
+    return PRESET_VENDORS[first] ?? null;
+}
+
+/**
  * The material of a slot: the profile's where the id is a known one, and the
  * coarse `tray_type` the AMS reports next to it otherwise.
  *

--- a/scripts/test-server/scenario.js
+++ b/scripts/test-server/scenario.js
@@ -61,7 +61,7 @@ const busyTray = id => ({ id: String(id), state: 17 });
  * defaults and from what the user set on the printer, so it carries a material
  * and a colour but an all zero uuid.
  */
-function thirdPartyTray(id, color) {
+function thirdPartyTray(id, color, idx = "GFL99", type = "PLA") {
     return {
         id: String(id),
         state: 11,
@@ -77,9 +77,9 @@ function thirdPartyTray(id, color) {
         tray_color: color,
         tray_diameter: "1.75",
         tray_id_name: "",
-        tray_info_idx: "GFL99",
+        tray_info_idx: idx,
         tray_sub_brands: "",
-        tray_type: "PLA",
+        tray_type: type,
         tray_uuid: "00000000000000000000000000000000",
         tray_weight: "0",
         xcam_info: "000000000000000000000000",
@@ -181,7 +181,9 @@ export const AMS_UNITS = [
     htUnit(132, [bambuTray(0, { ...SILK, colors: ["EC984CFF", "6CD4BCFF", "A66EB9FF", "D87694FF"], uuid: "AF15D6820C934E7BA05F31C86D2E9074", tagUid: "BAA8227400000144", remain: 100 })]),
     htUnit(133, [emptyTray(0)]),
     htUnit(134, [busyTray(0)]),
-    htUnit(135, [thirdPartyTray(0, "0ACC38FF")]),
+    // A vendor preset picked in Bambu Studio, SUNLU PETG in black, the way an
+    // X1E reported it on 2026-09-08: what the create dialog proposes from
+    htUnit(135, [thirdPartyTray(0, "161616FF", "GFSNL08", "PETG")]),
 ];
 
 /**

--- a/test/match.test.js
+++ b/test/match.test.js
@@ -1,7 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { colorSetDistance, spoolFitsSlot, spoolIsChipless, uniqueSpoolForSlot } from "../public/match.js";
+import { catalogueColors, colorSetDistance, rankCatalogueEntries, spoolFitsSlot, spoolIsChipless, uniqueSpoolForSlot } from "../public/match.js";
 
 const slot = (over = {}) => ({ tray_info_idx: "GFL99", tray_type: "PLA", tray_color: "0EE2A0FF", cols: ["0EE2A0FF"], ...over });
 const spool = (id, over = {}) => ({
@@ -74,4 +74,64 @@ test("a tagged twin does not count, a twin assigned to another slot does not cou
 test("no spools, or none fitting, is no answer", () => {
     assert.equal(uniqueSpoolForSlot(slot(), []), null);
     assert.equal(uniqueSpoolForSlot(slot(), [withFilament(1, { material: "ABS" })]), null);
+});
+
+/* ---- rankCatalogueEntries ---- */
+
+// Sunlu PETG as SpoolmanDB lists it, cut down to what decides: the slot on an
+// X1E reported 161616, the catalogue's nearest is "High Speed Matte PETG -
+// Black" at 151616, and "Black" is 000000. Read off the real catalogue on
+// 2026-09-08.
+const sunlu = (name, hex, weight = 1000) => ({ manufacturer: "Sunlu", material: "PETG", name, color_hex: hex, weight });
+const SUNLU_PETG = [
+    sunlu("Black", "000000"),
+    sunlu("High Speed Matte PETG - Black", "151616"),
+    sunlu("High Speed Matte PETG - Blue", "3a39bb"),
+    sunlu("White", "FFFFFF"),
+];
+const blackSlot = { tray_info_idx: "GFSNL08", tray_type: "PETG", tray_color: "161616FF", cols: ["161616FF"] };
+
+test("the entry nearest the slot's colour comes first, with its distance", () => {
+    const [best, second] = rankCatalogueEntries(SUNLU_PETG, blackSlot);
+    assert.equal(best.entry.name, "High Speed Matte PETG - Black");
+    assert.ok(best.distance > 0 && best.distance < 2, `nearest at ${best.distance}`);
+    assert.equal(second.entry.name, "Black");
+    assert.equal(best.tooHeavy, false);
+    assert.equal(best.offLine, false);
+});
+
+test("an exact colour ranks at distance 0", () => {
+    const [best] = rankCatalogueEntries(SUNLU_PETG, { ...blackSlot, tray_color: "151616FF", cols: ["151616FF"] });
+    assert.equal(best.entry.name, "High Speed Matte PETG - Black");
+    assert.equal(best.distance, 0);
+});
+
+test("a spool heavier than an AMS takes ranks behind every fitting one, but not on the holder", () => {
+    const entries = [sunlu("Black 3 kg", "161616", 3000), sunlu("White", "FFFFFF")];
+
+    const inAms = rankCatalogueEntries(entries, blackSlot);
+    assert.equal(inAms[0].entry.name, "White");
+    assert.equal(inAms[1].tooHeavy, true);
+
+    const onHolder = rankCatalogueEntries(entries, blackSlot, { external: true });
+    assert.equal(onHolder[0].entry.name, "Black 3 kg");
+    assert.equal(onHolder[0].tooHeavy, false);
+});
+
+test("a preset that names a product line ranks that line first", () => {
+    const poly = (name, hex) => ({ manufacturer: "Polymaker", material: "PETG", name, color_hex: hex, weight: 1000 });
+    const entries = [poly("PolyMax™ PETG Blue", "2850E0"), poly("PolyLite™ PETG Electric Blue", "0076CF")];
+    const slot = { tray_info_idx: "GFG60", tray_type: "PETG", tray_color: "2850E0FF", cols: ["2850E0FF"] };
+
+    assert.equal(rankCatalogueEntries(entries, slot)[0].entry.name, "PolyMax™ PETG Blue");
+    const [best] = rankCatalogueEntries(entries, slot, { line: "PolyLite" });
+    assert.equal(best.entry.name, "PolyLite™ PETG Electric Blue");
+    assert.equal(best.offLine, false);
+});
+
+test("a catalogue entry's colours are read whole", () => {
+    assert.deepEqual(catalogueColors({ color_hex: "#FF9016" }), ["ff9016"]);
+    assert.deepEqual(catalogueColors({ color_hexes: ["000000", "C12E1F"], color_hex: "000000" }), ["000000", "c12e1f"]);
+    assert.deepEqual(catalogueColors({}), []);
+    assert.deepEqual(rankCatalogueEntries([], blackSlot), []);
 });

--- a/test/materials.test.js
+++ b/test/materials.test.js
@@ -9,6 +9,7 @@ import {
     bambuProfile,
     materialFamily,
     materialsAgree,
+    presetVendor,
     slotMaterial,
     slotPreset,
 } from "../public/materials.js";
@@ -126,4 +127,23 @@ test("an id the table does not know keeps its id, and no id is no preset", () =>
 test("the dashboard imports the table rather than keeping its own", () => {
     const frontend = fs.readFileSync(path.join(root, "public", "frontend.js"), "utf8");
     assert.match(frontend, /import\s*\{[^}]*materialsAgree[^}]*\}\s*from\s*"\.\/materials\.js"/);
+});
+
+/* ---- presetVendor ---- */
+
+test("a vendor preset names its manufacturer as SpoolmanDB spells it", () => {
+    // SUNLU PETG and PolyLite PETG chosen in Bambu Studio, read off an X1E's
+    // external holder on 2026-09-08 as GFSNL08 and GFG60
+    assert.deepEqual(presetVendor(slotPreset({ tray_info_idx: "GFSNL08" })), { vendor: "Sunlu", line: null });
+    assert.deepEqual(presetVendor(slotPreset({ tray_info_idx: "GFG60" })), { vendor: "Polymaker", line: "PolyLite" });
+    assert.deepEqual(presetVendor(slotPreset({ tray_info_idx: "GFL01" })), { vendor: "Polymaker", line: "PolyTerra" });
+    assert.deepEqual(presetVendor(slotPreset({ tray_info_idx: "GFL03" })), { vendor: "eSUN", line: null });
+});
+
+test("a Bambu, a generic or a custom preset names no manufacturer", () => {
+    assert.equal(presetVendor(slotPreset({ tray_info_idx: "GFA00" })), null);
+    assert.equal(presetVendor(slotPreset({ tray_info_idx: "GFL99" })), null);
+    assert.equal(presetVendor(slotPreset({ tray_info_idx: "Pdd34802" })), null);
+    assert.equal(presetVendor(slotPreset({ tray_info_idx: "" })), null);
+    assert.equal(presetVendor(null), null);
 });


### PR DESCRIPTION
## What

The create dialog of a chipless slot proposes the filament from the slot's preset (issue #47). Nothing is created by itself; the proposal is what the form starts with.

- A vendor preset chosen in Bambu Studio, "SUNLU PETG" or "PolyLite PETG", names the manufacturer. `presetVendor()` in `public/materials.js` maps the profile name's first word to the manufacturer as SpoolmanDB spells it, and to the product line where the name carries one (PolyLite, PolyTerra, Fiberon are Polymaker).
- The dialog opens with the manufacturer step and field filled in, spelled the way this Spoolman or the catalogue already spells it, so "SUNLU" from the preset does not create a second vendor next to "Sunlu". The material starts as the preset's, "PLA-CF" rather than the "PLA" the AMS reports next to it.
- The catalogue, narrowed to that maker and material, is ranked by `rankCatalogueEntries()` in `public/match.js`: a filament sold on a spool heavier than 1 kg cannot sit in an AMS and ranks behind every fitting one (the external holder takes any size), an entry carrying the preset's line word ranks before the maker's other lines, then the nearest colour to the slot's. The best entry is filled in once, on open, with a line saying how near: "Proposed from the slot's preset "SUNLU PETG": High Speed Matte PETG - Black, the nearest colour in the catalogue (151616 for the slot's 161616). Pick another filament above if it is not this one".
- A Bambu, a generic or a custom preset names no manufacturer, and the dialog then starts as before: the nearest colour among every maker's filaments would be a guess.
- The mock scenario's HT-H is now a SUNLU PETG in black, the way the X1E reported it.

## Why this and not automatic creation

The colour a slot reports is what somebody picked on the printer's screen, from a fixed palette, or typed in Bambu Studio, so it rarely equals the catalogue's value: the X1E's 161616 meets nothing exactly, and Sunlu alone lists "Black", "High Speed Matte PETG - Black" and "Transparent" side by side. Polymaker PETG has 130 catalogue entries, six per name. A machine would guess; a proposal the person can correct does not.

Read off an X1E on 2026-09-08 whose holder carried SUNLU PETG and PolyLite PETG chosen in Bambu Studio, arriving as GFSNL08 and GFG60. Built in vendor profiles are `GF` codes on the X1 family as on the P1S; the `P` hash seen on the P2S was a profile downloaded from the cloud library.

## Verified

- In the browser, mock printer against a real SpoolmanDB catalogue (`scripts/test-server --spoolman <url>`): the create dialog of the HT-H slot opened with Sunlu, PETG, "High Speed Matte PETG - Black", 1000 g, 168 g spool, density 1.26 and the colour 151616 filled in, hint as above, no console errors.
- `node --test`: 630 tests, 628 pass, 2 todo. `test/materials.test.js` and `test/match.test.js` carry the real ids and the Sunlu entries.
- Not run on the X1E itself yet; a Polymaker preset on its holder is the case where the nearest colour (2850E0 meets nothing) is worth a look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
