### PR TITLE
chore: bump the version to 1.3.0-dev.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 -----------------------------------------------------------------------------------------------
-Unreleased
+Version 1.3.0-dev.17
    - Features:
       - The create dialog of a chipless slot proposes the filament from the slot's preset (issue #47). A vendor preset chosen in Bambu Studio, "SUNLU PETG" or "PolyLite PETG", names the manufacturer, so the catalogue is narrowed to that maker and the slot's material when the dialog opens, and the entry nearest the slot's colour is filled in as a proposal, with a line saying how near: "High Speed Matte PETG - Black, the nearest colour in the catalogue (151616 for the slot's 161616)". Nothing is created by itself; the proposal is what the form starts with
          - The colour the slot reports is what somebody picked on the printer's screen, from a fixed palette, or typed in Bambu Studio, so it rarely equals the catalogue's value and the nearest one is proposed rather than an exact one demanded. An AMS takes a spool of up to 1 kg, so for a slot inside one a filament sold on a heavier spool is ranked behind every fitting one; the external holder takes any size

--- a/docs/changelog-1.3.0-draft.md
+++ b/docs/changelog-1.3.0-draft.md
@@ -6,7 +6,7 @@ between two builds. This file is the consolidated release block, written into
 CHANGELOG.md in place of those dev blocks when the release build is cut, not
 before.
 
-Every dev build after dev.16 has to be folded in here as well, or regenerate the
+Every dev build after dev.17 has to be folded in here as well, or regenerate the
 whole block from the dev blocks at release time.
 
 ## Draft
@@ -86,6 +86,7 @@ Version 1.3.0
       - A 3rd party spool can be assigned without asking, where there is nothing to ask. "Assign 3rd party spools automatically" in the Tracking settings, off by default, links a spool without an RFID tag to the one Spoolman spool of the same material and colours that carries no tag and sits in no other slot. With two candidates the slot waits for a choice, and nothing is ever created in Spoolman. The assignment picker preselects the same spool, so the usual case with the setting off is one click (issue #47)
       - A 3rd party spool is called by the preset chosen for its slot: "Generic PLA preset", "SUNLU PETG preset" or "PLA · custom preset", and the dialog row is "Slot preset". A spool without a tag reports nothing of its own, only the filament preset somebody picked for the slot on the printer's screen or in the slicer, so the old "Tray profile" wording was wrong for it
       - The Logs page carries its choices as controls: a Source button over the server and the printers, a Log / Raw MQTT trace switch for a printer, and the download next to a line saying what the page shows and what the download would carry, "capture disabled" in front when that printer's trace is not being written. The switch writes into the address, so a link to a trace still opens the trace
+      - The create dialog of a chipless slot proposes the filament from the slot's preset. A vendor preset chosen in Bambu Studio, "SUNLU PETG" or "PolyLite PETG", names the manufacturer, so the catalogue is narrowed to that maker and the slot's material when the dialog opens, and the entry nearest the slot's colour is filled in as a proposal with a line saying how near. A filament sold on a spool heavier than 1 kg cannot sit in an AMS and ranks behind every fitting one; the external holder takes any size. Nothing is created by itself, and a Bambu, a generic or a custom preset names no manufacturer, so the dialog then starts as before (issue #47)
    - Fixes:
       - A spool is created with the weight the AMS reports instead of always starting at 100 % (issue #59)
       - Consumption is booked onto the right spool when two loaded spools look alike, and no longer onto a spool that never printed it

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bambulab-ams-spoolman-filamentstatus",
-  "version": "1.3.0-dev.16",
+  "version": "1.3.0-dev.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bambulab-ams-spoolman-filamentstatus",
-      "version": "1.3.0-dev.16",
+      "version": "1.3.0-dev.17",
       "license": "ISC",
       "dependencies": {
         "adm-zip": "^0.6.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "mqtt": "^5.15.2"
   },
   "name": "bambulab-ams-spoolman-filamentstatus",
-  "version": "1.3.0-dev.16",
+  "version": "1.3.0-dev.17",
   "main": "app.js",
   "type": "module",
   "engines": {

--- a/src/config.js
+++ b/src/config.js
@@ -32,7 +32,7 @@ export const apiKeysPath = path.join(dataDir, "apikeys.json");
 // brings the service back on its own or depends on the container policy.
 export const supervised = process.env.SUPERVISED === "1";
 
-export const version = "1.3.0-dev.16";
+export const version = "1.3.0-dev.17";
 export const PORT = 4000;
 
 /** The spellings a boolean environment variable is accepted in. */


### PR DESCRIPTION
## Summary

- `package.json`, `package-lock.json` and `src/config.js` move to 1.3.0-dev.17 together, because the publish workflow compares the tag against `package.json` and `src/config.js` is what the Web UI reports.
- The Unreleased block of the changelog becomes the dev.17 block: #152, the create dialog proposing the filament from a chipless slot's vendor preset.
- The release draft gets that entry.

This build exists for issue #47: the proposal is tested on the mock against a real SpoolmanDB catalogue and on a P2S for the fallback, and the X1E with its Sunlu and Polymaker presets is where it gets its first real run.

## Test plan

- [x] `node --test`: 630 tests, 628 pass, 2 todo
- [ ] After the merge, tag `v1.3.0-dev.17` on main and let the publish workflow build the image

🤖 Generated with [Claude Code](https://claude.com/claude-code)
