### PR TITLE
feat: the name behind a custom preset is learned from the first print with it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
 -----------------------------------------------------------------------------------------------
+Unreleased
+   - Features:
+      - The name behind a custom preset is learned from the first print with it. A preset from Bambu Studio's cloud library, or one of the user's own, reaches the slot as a hash such as "Pdd34802", and the printer never sends the name; the sliced file does, next to the id and the vendor. The service downloads that file for every print it books, so a slot reads "fibrelogy PLA Basic preset" from then on instead of "PLA · custom preset", the detail dialog says where the name came from, and the create dialog knows the manufacturer and proposes from the catalogue as it does for a shipped vendor profile
+         - Kept in printers/presets.json next to the assignments, one entry per hash, and in the diagnostics bundle. A preset renamed in the slicer replaces its old name on the next print. Read off a P2S on 2026-09-08: a Fiberlogy PLA from the cloud library was Pdd34802 on the slot and "fibrelogy PLA Basic @Bambu Lab P2S 0.6 nozzle" by "fibrelogy" in the file
+         - The vendor is spelled the way the preset spells it, which is the user's own spelling; the catalogue is matched without regard to case, and a spelling the catalogue does not know leaves the manufacturer field filled in and the proposal out
+
+-----------------------------------------------------------------------------------------------
 Version 1.3.0-dev.17
    - Features:
       - The create dialog of a chipless slot proposes the filament from the slot's preset (issue #47). A vendor preset chosen in Bambu Studio, "SUNLU PETG" or "PolyLite PETG", names the manufacturer, so the catalogue is narrowed to that maker and the slot's material when the dialog opens, and the entry nearest the slot's colour is filled in as a proposal, with a line saying how near: "High Speed Matte PETG - Black, the nearest colour in the catalogue (151616 for the slot's 161616)". Nothing is created by itself; the proposal is what the form starts with

--- a/public/frontend.js
+++ b/public/frontend.js
@@ -1250,12 +1250,16 @@ document.addEventListener("DOMContentLoaded", () => {
 
         // Typing a manufacturer that does not exist yet creates it on save
         const vendorNames = new Set((lookups.vendors || []).map(v => v.name.toLowerCase()));
-        $("sp-vendor").addEventListener("input", () => {
+        const noteNewVendor = () => {
             const value = $("sp-vendor").value.trim();
             $("sp-vendor-hint").textContent = value && !vendorNames.has(value.toLowerCase())
                 ? "New manufacturer, will be created"
                 : "";
-        });
+        };
+        $("sp-vendor").addEventListener("input", noteNewVendor);
+        // The field can start filled in from the slot's preset, and a
+        // manufacturer this Spoolman has not seen deserves the note then too.
+        noteNewVendor();
 
         // A filament can carry more than one colour, and both the AMS and the
         // catalogue report all of them. Spoolman keeps them as a list plus the

--- a/public/frontend.js
+++ b/public/frontend.js
@@ -1504,7 +1504,10 @@ document.addEventListener("DOMContentLoaded", () => {
         // note under it travel as one block.
         const withNote = (label, note) => `<span>${label}<br><span class="gc-muted">${note}</span></span>`;
         if (preset.kind === "custom") {
-            return withNote(`Custom preset ${id}`, "A vendor or user preset from the slicer. Its name is not in what the printer reports.");
+            if (preset.name) {
+                return withNote(`${escapeHtml(preset.name)} ${id}`, "A vendor or user preset from the slicer. Its name was learned from the sliced file of a print with it.");
+            }
+            return withNote(`Custom preset ${id}`, "A vendor or user preset from the slicer. Its name is not in what the printer reports; it is learned from the sliced file the first time a plate is printed with it.");
         }
         const label = preset.name ? `${escapeHtml(preset.name)} ${id}` : escapeHtml(preset.id);
         if (!chipless) return label;

--- a/public/materials.js
+++ b/public/materials.js
@@ -229,7 +229,11 @@ export function slotPreset(slot) {
         return { id, name: profile.name, kind };
     }
 
-    if (/^P[0-9A-F]{7}$/i.test(id)) return { id, name: null, kind: "custom" };
+    // The name behind a hash is learned from the sliced file of a print, see
+    // src/presets.js, and travels on the slot as preset_name and preset_vendor.
+    if (/^P[0-9A-F]{7}$/i.test(id)) {
+        return { id, name: slot?.preset_name ?? null, kind: "custom", vendor: slot?.preset_vendor ?? null };
+    }
 
     return { id, name: null, kind: "unknown" };
 }
@@ -263,9 +267,16 @@ const PRESET_VENDORS = {
  *
  * @param {object|null} preset - what `slotPreset()` returned
  * @returns {{vendor: string, line: string|null}|null} the manufacturer as
- *   SpoolmanDB spells it, and the product line word when the name carries one
+ *   SpoolmanDB spells it for a shipped profile, as the slicer spells it for a
+ *   learned one, and the product line word when the name carries one
  */
 export function presetVendor(preset) {
+    // A learned preset says who made it in the slicer's own words. There is no
+    // catalogue spelling to map it to, so the create dialog matches it against
+    // the manufacturers it knows without regard to case.
+    if (preset?.kind === "custom") {
+        return preset.vendor ? { vendor: preset.vendor, line: null } : null;
+    }
     if (preset?.kind !== "vendor" || !preset.name) return null;
     const first = preset.name.split(/\s+/)[0].toUpperCase();
     return PRESET_VENDORS[first] ?? null;

--- a/src/config.js
+++ b/src/config.js
@@ -22,6 +22,8 @@ export const serverLogFilePath = path.join(logsDir, "server.log");
 export const configPath = path.join(dataDir, "printers.json");
 // Manual AMS slot -> Spoolman spool assignments, written by the service itself.
 export const mappingsPath = path.join(dataDir, "mappings.json");
+// The slicer presets learned from sliced files, see src/presets.js
+export const presetsPath = path.join(dataDir, "presets.json");
 // Runtime configuration edited through the Web UI, see settings.js.
 export const settingsPath = path.join(dataDir, "settings.json");
 // API keys for callers that are not a browser, see apikeys.js. Its own file

--- a/src/diagnostics.js
+++ b/src/diagnostics.js
@@ -8,6 +8,7 @@ import { deprecatedConfig } from "./deprecation.js";
 import { logFileSet } from "./logger.js";
 import { printers } from "./printers.js";
 import { parseStoredFile } from "./mappings.js";
+import { allLearnedPresets } from "./presets.js";
 import { apiKeyCount } from "./apikeys.js";
 import { getSettingsView, legacyMode } from "./settings.js";
 import { state } from "./state.js";
@@ -226,6 +227,13 @@ export async function buildDiagnosticsBundle({ anonymize = true, scope = null } 
             ? Object.fromEntries(Object.entries(assignments).map(([serial, value]) => [maskSerial(serial), value]))
             : assignments;
         zip.addFile("mappings.json", Buffer.from(JSON.stringify({ schemaVersion, printers: exported }, null, 4)));
+    }
+    // Preset names carry no serial and no address, so they go in as they are:
+    // which hash a slot shows and what it was learned as is exactly what a
+    // "wrong preset name" report needs.
+    const learned = allLearnedPresets();
+    if (Object.keys(learned).length) {
+        zip.addFile("presets.json", Buffer.from(JSON.stringify({ schemaVersion: 1, presets: learned }, null, 4)));
     }
 
     if (included.server) await addLogFiles(zip, "logs/server", serverLogFilePath, mask);

--- a/src/gcode.js
+++ b/src/gcode.js
@@ -494,6 +494,7 @@ export function resolveRemotePaths(jobName, gcodeFile = null) {
  */
 export function parseSliceInfo(xml, projectSettings = null) {
     const colorSets = parseMultiColours(projectSettings);
+    const presets = parsePresets(projectSettings);
 
     // --- filaments ---
     const filaments = [];
@@ -535,7 +536,42 @@ export function parseSliceInfo(xml, projectSettings = null) {
         }
     }
 
-    return { filaments, totalLayers, rangesByFilamentIdx };
+    return { filaments, totalLayers, rangesByFilamentIdx, presets };
+}
+
+/**
+ * The presets a project names, one per filament of the project, id, preset
+ * name and vendor side by side.
+ *
+ * `project_settings.config` is JSON, and `filament_ids`, `filament_settings_id`
+ * and `filament_vendor` are three lists in the same order. The id is what a
+ * slot reports as `tray_info_idx` when that preset is chosen for it; for a
+ * preset from Studio's cloud library that is a hash, and this is the only place
+ * its name is written down. The "@BBL P2S 0.6 nozzle" tail of a preset name
+ * says which printer profile it was made for and is dropped.
+ *
+ * @param {string|null} json - the file's text
+ * @returns {{id: string, name: string|null, vendor: string|null}[]} empty when
+ *   the file is missing or names no ids
+ */
+export function parsePresets(json) {
+    if (!json) return [];
+    let parsed;
+    try {
+        parsed = JSON.parse(json);
+    } catch {
+        return [];
+    }
+    const ids = Array.isArray(parsed?.filament_ids) ? parsed.filament_ids : [];
+    const names = Array.isArray(parsed?.filament_settings_id) ? parsed.filament_settings_id : [];
+    const vendors = Array.isArray(parsed?.filament_vendor) ? parsed.filament_vendor : [];
+
+    return ids.map((id, index) => {
+        const rawName = typeof names[index] === "string" ? names[index].trim() : "";
+        const name = rawName.replace(/\s*@.*$/, "").trim() || null;
+        const vendor = typeof vendors[index] === "string" && vendors[index].trim() ? vendors[index].trim() : null;
+        return { id: String(id ?? "").trim(), name, vendor };
+    }).filter(preset => preset.id);
 }
 
 /**

--- a/src/mqtt.js
+++ b/src/mqtt.js
@@ -21,6 +21,7 @@ import {
 } from "./spoolman.js";
 import { fetchSliceInfo, calcFullConsumption, calcPartialConsumption, resolveSliceSlots, orderedAmsSlots, decodePrintMapping } from "./gcode.js";
 import { getMapping, clearMapping, setMapping, spoolIdsAssignedElsewhere } from "./mappings.js";
+import { learnPresets } from "./presets.js";
 import { uniqueSpoolForSlot } from "../public/match.js";
 import { describePrintError } from "./printerrors.js";
 import { createLocationSync, releaseSlotLocation } from "./location.js";
@@ -101,6 +102,30 @@ function broadcastAmsEnvironment(printer, amsUnits, now) {
     printer.lastAmsEnvBroadcast = serialised;
     printer.lastAmsEnvBroadcastTime = now.getTime();
     broadcastSSE({ type: "ams_env", printer: printer.id, amsEnv });
+}
+
+/**
+ * Fetches the sliced file of a job and learns what it names.
+ *
+ * The names behind the preset hashes of chipless slots are in that file and
+ * nowhere else, so they are kept whenever a file is read, by the print handler
+ * when a print starts and by the manual `?job=` test of `/api/print` alike.
+ * The next slot update shows them.
+ *
+ * @param {object} printer - the printer runtime object
+ * @param {string} jobName - `subtask_name` of the job
+ * @param {string|null} [gcodeFile] - `gcode_file` of the job, when reported
+ * @returns {Promise<object|null>} what `fetchSliceInfo()` returned
+ */
+export async function loadSliceInfo(printer, jobName, gcodeFile = null) {
+    const sliceInfo = await fetchSliceInfo(printer, jobName, gcodeFile);
+    if (!sliceInfo) return null;
+
+    for (const preset of learnPresets(sliceInfo, jobName)) {
+        console.log(printer.name, printer.logFilePath,
+            `[Print] Learned the preset ${preset.id}: "${preset.name}"${preset.vendor ? ` by ${preset.vendor}` : ""}`);
+    }
+    return sliceInfo;
 }
 
 /**
@@ -316,7 +341,7 @@ export async function handlePrintStateChange(printer, print) {
 
         console.log(printer.name, printer.logFilePath, `[Print] Print running: "${jobName}", fetching slice info via FTPS...`);
         try {
-            printer.currentSliceInfo = await fetchSliceInfo(printer, jobName, printer.currentGcodeFile);
+            printer.currentSliceInfo = await loadSliceInfo(printer, jobName, printer.currentGcodeFile);
             if (printer.currentSliceInfo) {
                 console.log(printer.name, printer.logFilePath, `[Print] Slice info loaded: ${printer.currentSliceInfo.filaments.length} filament(s), ${printer.currentSliceInfo.totalLayers} layers`);
             } else {

--- a/src/presets.js
+++ b/src/presets.js
@@ -1,0 +1,120 @@
+import fs from "fs-extra";
+import { presetsPath, serverLogFilePath } from "./config.js";
+
+/**
+ * The slicer presets this service has learned the names of.
+ *
+ * A chipless slot reports the preset chosen for it as `tray_info_idx`. For a
+ * preset Bambu Studio ships that is a "GF" id whose name `public/materials.js`
+ * knows. For a preset from Studio's cloud library, or one of the user's own, it
+ * is "P" and seven hex digits, and the name behind the hash is in the slicer
+ * and nowhere the printer reports. It is in the sliced file, though: the
+ * `project_settings.config` of every print names each filament's id, preset and
+ * vendor side by side, and the service downloads that file for every print it
+ * books. So a hash is learned the first time a plate is printed with it, and
+ * from then on the slot reads "fibrelogy PLA Basic preset" rather than
+ * "PLA · custom preset", and the create dialog knows the manufacturer.
+ *
+ * Read off a P2S on 2026-09-08: a Fiberlogy PLA from the cloud library was
+ * `Pdd34802` on the slot, and the sliced file carried `Pdd34802`, "fibrelogy
+ * PLA Basic @Bambu Lab P2S 0.6 nozzle" and "fibrelogy" at the same index.
+ *
+ * Kept in `printers/presets.json` next to the assignments, keyed by the hash in
+ * upper case, and read once at start. The file is small and grows by one entry
+ * per new preset, so it is rewritten whole.
+ */
+
+const PRESETS_SCHEMA_VERSION = 1;
+
+/** A learnable id: the hash of a preset Bambu Studio does not ship. */
+const CUSTOM_ID = /^P[0-9A-F]{7}$/i;
+
+let presets = null;
+
+function load() {
+    if (presets) return presets;
+    try {
+        const parsed = JSON.parse(fs.readFileSync(presetsPath, "utf-8"));
+        presets = parsed && typeof parsed.presets === "object" && parsed.presets !== null ? parsed.presets : {};
+    } catch (err) {
+        if (err.code !== "ENOENT") {
+            console.error("Server", serverLogFilePath, "Could not read presets.json, starting empty:", err.message);
+        }
+        presets = {};
+    }
+    return presets;
+}
+
+function persist() {
+    const tmp = `${presetsPath}.tmp`;
+    try {
+        fs.outputFileSync(tmp, JSON.stringify({ schemaVersion: PRESETS_SCHEMA_VERSION, presets }, null, 2));
+        fs.renameSync(tmp, presetsPath);
+    } catch (err) {
+        console.error("Server", serverLogFilePath, "Failed to save presets.json:", err.message);
+        try { fs.removeSync(tmp); } catch {}
+    }
+}
+
+/** Whether an id is a preset hash whose name can only come from a sliced file. */
+export function isCustomPresetId(id) {
+    return CUSTOM_ID.test(String(id ?? "").trim());
+}
+
+/**
+ * What is known about a preset hash, or null.
+ *
+ * @param {string} id - `tray_info_idx` of a slot
+ * @returns {{name: string, vendor: string|null, learnedAt: string, from: string|null}|null}
+ */
+export function learnedPreset(id) {
+    const key = String(id ?? "").trim().toUpperCase();
+    if (!CUSTOM_ID.test(key)) return null;
+    return load()[key] ?? null;
+}
+
+/**
+ * Learns the presets a sliced file names, and says which were new.
+ *
+ * Only the hashes are kept: a "GF" id is Bambu Studio's own and its name is in
+ * `materials.js` already. A name that changed since it was learned replaces
+ * the old one, because the user renamed the preset in the slicer and the slot
+ * should say what the slicer says.
+ *
+ * @param {{presets?: {id: string, name: string|null, vendor: string|null}[]}} sliceInfo - as `parseSliceInfo()` returns it
+ * @param {string|null} [jobName] - the print the file belongs to, for the record
+ * @returns {{id: string, name: string, vendor: string|null}[]} the presets learned or changed by this call
+ */
+export function learnPresets(sliceInfo, jobName = null) {
+    const table = load();
+    const learned = [];
+
+    for (const preset of sliceInfo?.presets ?? []) {
+        const key = String(preset?.id ?? "").trim().toUpperCase();
+        if (!CUSTOM_ID.test(key) || !preset.name) continue;
+
+        const known = table[key];
+        if (known && known.name === preset.name && (known.vendor ?? null) === (preset.vendor ?? null)) continue;
+
+        table[key] = {
+            name: preset.name,
+            vendor: preset.vendor ?? null,
+            learnedAt: new Date().toISOString(),
+            from: jobName ?? null,
+        };
+        learned.push({ id: key, name: preset.name, vendor: preset.vendor ?? null });
+    }
+
+    if (learned.length) persist();
+    return learned;
+}
+
+/** Every learned preset, by hash, for the diagnostics bundle. */
+export function allLearnedPresets() {
+    return { ...load() };
+}
+
+/** Test hook: forgets the loaded table so the next call reads the file again. */
+export function resetPresetsForTests() {
+    presets = null;
+}

--- a/src/routes.js
+++ b/src/routes.js
@@ -34,9 +34,9 @@ import {
     patchSpoolFields,
     getCachedExternalFilaments,
 } from "./spoolman.js";
-import { fetchSliceInfo, calcFullConsumption, calcPartialConsumption, testFtpsConnection, resolveSliceSlots, orderedAmsSlots, printStageName, isPreparingStage } from "./gcode.js";
+import { calcFullConsumption, calcPartialConsumption, testFtpsConnection, resolveSliceSlots, orderedAmsSlots, printStageName, isPreparingStage } from "./gcode.js";
 import { consumptionCandidate, matchConsumption } from "./ams.js";
-import { setupMqtt, closeMqtt, broadcastSlotUpdate, broadcastSSE, testMqttConnection, resetOfflineBackoff, ACTIVE_STATES, printResultCleared } from "./mqtt.js";
+import { setupMqtt, closeMqtt, broadcastSlotUpdate, broadcastSSE, testMqttConnection, resetOfflineBackoff, ACTIVE_STATES, printResultCleared, loadSliceInfo } from "./mqtt.js";
 import { getMappings, setMapping, clearMapping, clearPrinterMappings } from "./mappings.js";
 import {
     claimSlotLocation,
@@ -628,7 +628,7 @@ export function registerRoutes(app, printers) {
         const alreadyLookedFor = !req.query.job && printer.lastSliceFetch?.jobName === jobName;
         if (jobName && !sliceInfo && !alreadyLookedFor) {
             try {
-                sliceInfo = await fetchSliceInfo(printer, jobName, req.query.job ? null : printer.currentGcodeFile);
+                sliceInfo = await loadSliceInfo(printer, jobName, req.query.job ? null : printer.currentGcodeFile);
             } catch (err) {
                 // non-fatal, surface the error in the response
                 return res.json({

--- a/src/uispool.js
+++ b/src/uispool.js
@@ -1,3 +1,4 @@
+import { learnedPreset } from "./presets.js";
 import { consumptionKey } from "./gcode.js";
 import { orNull, slotColors, SLOT_OPTIONS } from "./utils.js";
 
@@ -27,7 +28,13 @@ import { orNull, slotColors, SLOT_OPTIONS } from "./utils.js";
  */
 function pickSlot(slot) {
     if (!slot) return null;
+    // The name and vendor behind a preset hash, learned from a sliced file.
+    // Sent with the slot so the client names the preset without a table of its
+    // own, and so a newly learned name reaches the dashboard as a change.
+    const learned = learnedPreset(slot.tray_info_idx);
     return {
+        preset_name: learned?.name ?? null,
+        preset_vendor: learned?.vendor ?? null,
         tray_uuid: orNull(slot.tray_uuid),
         tray_type: orNull(slot.tray_type),
         tray_sub_brands: orNull(slot.tray_sub_brands),

--- a/test/fixtures/p2s_cloud_preset.config
+++ b/test/fixtures/p2s_cloud_preset.config
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<config>
+  <header>
+    <header_item key="X-BBL-Client-Type" value="slicer"/>
+    <header_item key="X-BBL-Client-Version" value="02.08.02.61"/>
+  </header>
+  <plate>
+    <metadata key="index" value="1"/>
+    <metadata key="extruder_type" value="0"/>
+    <metadata key="nozzle_volume_type" value="0"/>
+    <metadata key="printer_model_id" value="N7"/>
+    <metadata key="nozzle_diameters" value="0.6"/>
+    <metadata key="timelapse_type" value="0"/>
+    <metadata key="prediction" value="1231"/>
+    <metadata key="weight" value="7.50"/>
+    <metadata key="pause_count" value="0"/>
+    <metadata key="first_layer_time" value="49.487061"/>
+    <metadata key="outside" value="false"/>
+    <metadata key="support_used" value="false"/>
+    <metadata key="label_object_enabled" value="false"/>
+    <metadata key="support_material_on_wipe_tower" value="false"/>
+    <metadata key="enable_filament_dynamic_map" value="false"/>
+    <metadata key="has_filament_switcher" value="false"/>
+    <metadata key="filament_maps" value="1 1 1 1 1 1 1 1"/>
+    <metadata key="limit_filament_maps" value="0 0 0 0 0 0 0 0"/>
+    <object identify_id="58" name="Cube" skipped="false" />
+    <filament id="8" tray_info_idx="Pdd34802" type="PLA" color="#0EE2A0" used_m="2.52" used_g="7.50" group_id="0" nozzle_diameter="0.60" volume_type="Standard" used_for_object="true" used_for_support="false" total_load_time="26.00" total_unload_time="0.00"/>
+    <nozzle id="0" extruder_id="1" nozzle_diameter="0.6" volume_type="Standard"/>
+    <layer_filament_lists>
+      <layer_filament_list filament_list="7" layer_ranges="0 84" />
+    </layer_filament_lists>
+  </plate>
+</config>

--- a/test/fixtures/p2s_cloud_preset.settings.json
+++ b/test/fixtures/p2s_cloud_preset.settings.json
@@ -1,0 +1,62 @@
+{
+  "filament_ids": [
+    "GFA00",
+    "GFA06",
+    "GFL99",
+    "GFA00",
+    "GFA00",
+    "GFB00",
+    "GFG02",
+    "Pdd34802"
+  ],
+  "filament_settings_id": [
+    "Bambu PLA Basic @BBL P2S 0.6 nozzle",
+    "Bambu PLA Silk+ @BBL P2S 0.6 nozzle",
+    "Generic PLA @BBL P2S",
+    "Bambu PLA Basic @BBL P2S 0.6 nozzle",
+    "Bambu PLA Basic @BBL P2S 0.6 nozzle",
+    "Bambu ABS @BBL P2S 0.6 nozzle",
+    "Bambu PETG HF @BBL P2S 0.6 nozzle",
+    "fibrelogy PLA Basic @Bambu Lab P2S 0.6 nozzle"
+  ],
+  "filament_vendor": [
+    "Bambu Lab",
+    "Bambu Lab",
+    "Generic",
+    "Bambu Lab",
+    "Bambu Lab",
+    "Bambu Lab",
+    "Bambu Lab",
+    "fibrelogy"
+  ],
+  "filament_multi_colour": [
+    "#F55A74",
+    "#C8C8C8",
+    "#5E6345",
+    "#000000",
+    "#F7E6DE",
+    "#000000",
+    "#000000",
+    "#0EE2A0"
+  ],
+  "filament_colour": [
+    "#F55A74",
+    "#C8C8C8",
+    "#5E6345",
+    "#000000",
+    "#F7E6DE",
+    "#000000",
+    "#000000",
+    "#0EE2A0"
+  ],
+  "filament_type": [
+    "PLA",
+    "PLA",
+    "PLA",
+    "PLA",
+    "PLA",
+    "ABS",
+    "PETG",
+    "PLA"
+  ]
+}

--- a/test/materials.test.js
+++ b/test/materials.test.js
@@ -113,8 +113,8 @@ test("a shipped id is named and sorted into Bambu, Generic or a vendor", () => {
 });
 
 test("a slicer hash is a custom preset without a name, as a P2S reported a library vendor", () => {
-    assert.deepEqual(slotPreset({ tray_info_idx: "Pdd34802" }), { id: "Pdd34802", name: null, kind: "custom" });
-    assert.deepEqual(slotPreset({ tray_info_idx: "P8d19ba6" }), { id: "P8d19ba6", name: null, kind: "custom" });
+    assert.deepEqual(slotPreset({ tray_info_idx: "Pdd34802" }), { id: "Pdd34802", name: null, kind: "custom", vendor: null });
+    assert.deepEqual(slotPreset({ tray_info_idx: "P8d19ba6" }), { id: "P8d19ba6", name: null, kind: "custom", vendor: null });
 });
 
 test("an id the table does not know keeps its id, and no id is no preset", () => {
@@ -146,4 +146,17 @@ test("a Bambu, a generic or a custom preset names no manufacturer", () => {
     assert.equal(presetVendor(slotPreset({ tray_info_idx: "Pdd34802" })), null);
     assert.equal(presetVendor(slotPreset({ tray_info_idx: "" })), null);
     assert.equal(presetVendor(null), null);
+});
+
+/* ---- learned presets ---- */
+
+test("a learned name and vendor travel on the slot for a custom preset", () => {
+    const slot = { tray_info_idx: "Pdd34802", tray_type: "PLA", preset_name: "fibrelogy PLA Basic", preset_vendor: "fibrelogy" };
+    assert.deepEqual(slotPreset(slot), { id: "Pdd34802", name: "fibrelogy PLA Basic", kind: "custom", vendor: "fibrelogy" });
+    assert.deepEqual(presetVendor(slotPreset(slot)), { vendor: "fibrelogy", line: null });
+
+    // Not learned yet: a hash without a name, and no manufacturer to propose
+    const bare = slotPreset({ tray_info_idx: "Pdd34802", tray_type: "PLA" });
+    assert.deepEqual(bare, { id: "Pdd34802", name: null, kind: "custom", vendor: null });
+    assert.equal(presetVendor(bare), null);
 });

--- a/test/presets.test.js
+++ b/test/presets.test.js
@@ -1,0 +1,91 @@
+import test, { after, before } from "node:test";
+import assert from "node:assert/strict";
+import fs from "fs-extra";
+import os from "os";
+import path from "path";
+import { fileURLToPath } from "url";
+
+// The module reads its path from config.js at import time, so DATA_DIR has to
+// point at a throwaway directory before the first import.
+let dir, presetsPath, learnPresets, learnedPreset, allLearnedPresets, isCustomPresetId, resetPresetsForTests, parseSliceInfo;
+
+before(async () => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), "ams-presets-"));
+    process.env.DATA_DIR = path.join(dir, "printers");
+    process.env.LOG_DIR = path.join(dir, "logs");
+    fs.ensureDirSync(process.env.DATA_DIR);
+    fs.ensureDirSync(process.env.LOG_DIR);
+
+    ({ presetsPath } = await import("../src/config.js"));
+    ({ learnPresets, learnedPreset, allLearnedPresets, isCustomPresetId, resetPresetsForTests } = await import("../src/presets.js"));
+    ({ parseSliceInfo } = await import("../src/gcode.js"));
+});
+
+after(() => { fs.removeSync(dir); });
+
+const fixtures = path.join(path.dirname(fileURLToPath(import.meta.url)), "fixtures");
+const read = name => fs.readFileSync(path.join(fixtures, name), "utf-8");
+
+// A plate sliced on a P2S on 2026-09-08 with a Fiberlogy PLA from Bambu
+// Studio's cloud library in A3, exported with "Export sliced file". The slot
+// reported Pdd34802 for that spool; the file names it.
+const cloudPlate = () => parseSliceInfo(read("p2s_cloud_preset.config"), read("p2s_cloud_preset.settings.json"));
+
+test("the sliced file names every preset of the project, id, name and vendor side by side", () => {
+    const { presets, filaments } = cloudPlate();
+    assert.equal(presets.length, 8);
+    assert.deepEqual(presets[7], { id: "Pdd34802", name: "fibrelogy PLA Basic", vendor: "fibrelogy" });
+    // The "@BBL P2S 0.6 nozzle" tail names the printer profile and is dropped
+    assert.deepEqual(presets[0], { id: "GFA00", name: "Bambu PLA Basic", vendor: "Bambu Lab" });
+    assert.deepEqual(presets[2], { id: "GFL99", name: "Generic PLA", vendor: "Generic" });
+    // The one filament the plate prints is the eighth, and it carries the hash
+    assert.deepEqual(filaments.map(f => f.tray_info_idx), ["Pdd34802"]);
+});
+
+test("without project settings there are no presets, and a broken file yields none", () => {
+    assert.deepEqual(parseSliceInfo(read("p2s_cloud_preset.config")).presets, []);
+    assert.deepEqual(parseSliceInfo(read("p2s_cloud_preset.config"), "not json").presets, []);
+    assert.deepEqual(parseSliceInfo(read("p2s_cloud_preset.config"), "{}").presets, []);
+});
+
+test("only the hashes are learned, and they are written to disk", () => {
+    const learned = learnPresets(cloudPlate(), "Cube-P2S-fibrelogy-A3");
+    assert.deepEqual(learned, [{ id: "PDD34802", name: "fibrelogy PLA Basic", vendor: "fibrelogy" }]);
+
+    assert.deepEqual(learnedPreset("Pdd34802"), learnedPreset("PDD34802"));
+    assert.equal(learnedPreset("Pdd34802").name, "fibrelogy PLA Basic");
+    assert.equal(learnedPreset("Pdd34802").vendor, "fibrelogy");
+    assert.equal(learnedPreset("Pdd34802").from, "Cube-P2S-fibrelogy-A3");
+    assert.equal(learnedPreset("GFA00"), null);
+    assert.equal(learnedPreset(""), null);
+
+    const stored = JSON.parse(fs.readFileSync(presetsPath, "utf-8"));
+    assert.equal(stored.schemaVersion, 1);
+    assert.equal(stored.presets.PDD34802.name, "fibrelogy PLA Basic");
+});
+
+test("a preset already known is not learned again, a renamed one replaces its name", () => {
+    assert.deepEqual(learnPresets(cloudPlate(), "again"), []);
+
+    const renamed = { presets: [{ id: "Pdd34802", name: "Fiberlogy Easy PLA", vendor: "Fiberlogy" }] };
+    assert.deepEqual(learnPresets(renamed, "later"), [{ id: "PDD34802", name: "Fiberlogy Easy PLA", vendor: "Fiberlogy" }]);
+    assert.equal(learnedPreset("Pdd34802").name, "Fiberlogy Easy PLA");
+
+    // A name is required; an id without one teaches nothing
+    assert.deepEqual(learnPresets({ presets: [{ id: "P1234567", name: null, vendor: "x" }] }), []);
+    assert.equal(learnedPreset("P1234567"), null);
+});
+
+test("the table survives a restart, read back from the file", () => {
+    resetPresetsForTests();
+    assert.equal(learnedPreset("Pdd34802").name, "Fiberlogy Easy PLA");
+    assert.deepEqual(Object.keys(allLearnedPresets()), ["PDD34802"]);
+});
+
+test("a custom id is a P and seven hex digits", () => {
+    assert.equal(isCustomPresetId("Pdd34802"), true);
+    assert.equal(isCustomPresetId("P478b216"), true);
+    assert.equal(isCustomPresetId("GFA00"), false);
+    assert.equal(isCustomPresetId("Pdd3480"), false);
+    assert.equal(isCustomPresetId(null), false);
+});


### PR DESCRIPTION
## What

The name behind a custom preset is learned from the first print with it.

- A preset from Bambu Studio's cloud library, or one of the user's own, reaches the slot as a hash such as `Pdd34802`, and the printer never sends the name. The sliced file does: `project_settings.config` lists `filament_ids`, `filament_settings_id` and `filament_vendor` side by side. `parsePresets()` in `src/gcode.js` reads them, and `src/presets.js` keeps the hashes in `printers/presets.json`, one entry per hash, a renamed preset replacing its old name on the next print.
- `loadSliceInfo()` in `src/mqtt.js` wraps the fetch and the learning, for the print handler and the manual `?job=` test of `/api/print` alike. The log reads `[Print] Learned the preset PDD34802: "fibrelogy PLA Basic" by fibrelogy`.
- The slot projection carries `preset_name` and `preset_vendor`, so a slot reads "fibrelogy PLA Basic preset" instead of "PLA · custom preset", the detail dialog says the name was learned from a sliced file, and the create dialog fills in the manufacturer and proposes from the catalogue the way it does for a shipped vendor profile (#152). The diagnostics bundle carries `presets.json`.
- The manufacturer is spelled the way the preset spells it, which is the user's own spelling. The catalogue is matched without regard to case; a spelling it does not know leaves the field filled in, with the "new manufacturer" note, and the proposal out.

## Why now

Read off a P2S on 2026-09-08: a Fiberlogy PLA from the cloud library was `Pdd34802` on the slot, and the sliced file carried `Pdd34802`, "fibrelogy PLA Basic @Bambu Lab P2S 0.6 nozzle" and "fibrelogy" at the same index. Bambu Studio writes the hash itself; OrcaSlicer wrote the parent's `GF` id for a user preset in an earlier file, so this only names presets of Studio prints. Second half of what #152 started for issue #47.

## Verified

- Live on the P2S: a cube printed from A3 with that preset, cancelled after the first layer. The log learned the preset, A3 read "fibrelogy PLA Basic preset", the create dialog opened with "fibrelogy" and PLA and "Nothing in the catalogue matches" (the catalogue spells it Fiberlogy), and `presets.json` held the entry.
- `node --test`: 637 tests, 635 pass, 2 todo. `test/presets.test.js` carries the real file, cut down to the three lists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
