### PR TITLE
fix: the sliced file of a print is downloaded once, not twice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 -----------------------------------------------------------------------------------------------
+Unreleased
+   - Fixes:
+      - The sliced file of a print is downloaded once, not twice. The dashboard asks for the print's figures as soon as the job has a name, while the printer is still preparing, and that request fetched the file for itself; the print handler fetched it again three seconds later when the print reached RUNNING, and logged "Learned the preset" a second time. Both now share one download, and the handler says "slice info already loaded" when the dashboard got there first. Seen on a P2S on 2026-09-08
+
+-----------------------------------------------------------------------------------------------
 Version 1.3.0-dev.18
    - Features:
       - The name behind a custom preset is learned from the first print with it. A preset from Bambu Studio's cloud library, or one of the user's own, reaches the slot as a hash such as "Pdd34802", and the printer never sends the name; the sliced file does, next to the id and the vendor. The service downloads that file for every print it books, so a slot reads "fibrelogy PLA Basic preset" from then on instead of "PLA · custom preset", the detail dialog says where the name came from, and the create dialog knows the manufacturer and proposes from the catalogue as it does for a shipped vendor profile

--- a/src/mqtt.js
+++ b/src/mqtt.js
@@ -129,6 +129,41 @@ export async function loadSliceInfo(printer, jobName, gcodeFile = null) {
 }
 
 /**
+ * The slice info of the printer's current job, fetched at most once.
+ *
+ * Two callers want it: the print handler when the state reaches RUNNING, and
+ * `/api/print`, which the dashboard asks every few seconds and which starts
+ * asking as soon as the job has a name, in PREPARE. Each used to download the
+ * file for itself, so every print cost two FTPS downloads three seconds apart,
+ * and the second one also logged "Learned the preset" a second time. Now the
+ * first caller's result is kept on the printer and a fetch still in flight is
+ * shared rather than started again.
+ *
+ * `freshStart` in `handlePrintStateChange()` clears both, so a cached file
+ * never outlives the job it belongs to.
+ *
+ * @param {object} printer - the printer runtime object
+ * @param {string} jobName - `subtask_name` of the job
+ * @param {string|null} [gcodeFile] - `gcode_file` of the job, when reported
+ * @returns {Promise<object|null>} what `fetchSliceInfo()` returned
+ */
+export function ensureSliceInfo(printer, jobName, gcodeFile = null) {
+    if (printer.currentSliceInfo) return Promise.resolve(printer.currentSliceInfo);
+    if (printer.sliceFetchInFlight?.jobName === jobName) return printer.sliceFetchInFlight.promise;
+
+    const promise = loadSliceInfo(printer, jobName, gcodeFile)
+        .then(sliceInfo => {
+            if (sliceInfo) printer.currentSliceInfo = sliceInfo;
+            return sliceInfo;
+        })
+        .finally(() => {
+            if (printer.sliceFetchInFlight?.promise === promise) printer.sliceFetchInFlight = null;
+        });
+    printer.sliceFetchInFlight = { jobName, promise };
+    return promise;
+}
+
+/**
  * Why the last slice info fetch came back empty, for the log.
  *
  * Two different problems used to share one sentence, "slice_info.config not
@@ -310,6 +345,7 @@ export async function handlePrintStateChange(printer, print) {
         printer.currentGcodeFile  = print.gcode_file || null;
         printer.currentSliceInfo  = null;
         printer.lastSliceFetch    = null;
+        printer.sliceFetchInFlight = null;
         printer.currentMapping    = null;
         printer.consumptionBooked = false;
         printer.sliceFetchDone    = false;
@@ -394,16 +430,22 @@ export async function handlePrintStateChange(printer, print) {
         printer.sliceFetchDone = true;
         printer.currentJobName = jobName;
 
-        console.log(printer.name, printer.logFilePath, `[Print] Print running: "${jobName}", fetching slice info via FTPS...`);
-        try {
-            printer.currentSliceInfo = await loadSliceInfo(printer, jobName, printer.currentGcodeFile);
-            if (printer.currentSliceInfo) {
-                console.log(printer.name, printer.logFilePath, `[Print] Slice info loaded: ${printer.currentSliceInfo.filaments.length} filament(s), ${printer.currentSliceInfo.totalLayers} layers`);
-            } else {
-                console.log(printer.name, printer.logFilePath, `[Print] ${sliceFetchFailure(printer.lastSliceFetch)}, consumption tracking unavailable for this print`);
+        if (printer.currentSliceInfo) {
+            // The dashboard asked /api/print while the job was preparing, and
+            // that request already fetched the file. See ensureSliceInfo().
+            console.log(printer.name, printer.logFilePath, `[Print] Print running: "${jobName}", slice info already loaded: ${printer.currentSliceInfo.filaments.length} filament(s), ${printer.currentSliceInfo.totalLayers} layers`);
+        } else {
+            console.log(printer.name, printer.logFilePath, `[Print] Print running: "${jobName}", fetching slice info via FTPS...`);
+            try {
+                const sliceInfo = await ensureSliceInfo(printer, jobName, printer.currentGcodeFile);
+                if (sliceInfo) {
+                    console.log(printer.name, printer.logFilePath, `[Print] Slice info loaded: ${sliceInfo.filaments.length} filament(s), ${sliceInfo.totalLayers} layers`);
+                } else {
+                    console.log(printer.name, printer.logFilePath, `[Print] ${sliceFetchFailure(printer.lastSliceFetch)}, consumption tracking unavailable for this print`);
+                }
+            } catch (err) {
+                console.error(printer.name, printer.logFilePath, `[Print] Could not fetch slice info: ${err.message}`);
             }
-        } catch (err) {
-            console.error(printer.name, printer.logFilePath, `[Print] Could not fetch slice info: ${err.message}`);
         }
     }
 

--- a/src/printers.js
+++ b/src/printers.js
@@ -125,6 +125,9 @@ function createRuntimePrinter(entry) {
         // The slots the printer says the running print is taking its filaments
         // from, decoded from print.mapping. Null until a print reports them.
         currentMapping: null,
+        // A slice info download still running for the current job, shared
+        // between the print handler and /api/print. See ensureSliceInfo().
+        sliceFetchInFlight: null,
         // The slots Bambu Studio sent the next job to, from the project_file
         // command the printer echoes before the print starts. Consumed by the
         // start of that print, see notePrintCommand() in mqtt.js.

--- a/src/routes.js
+++ b/src/routes.js
@@ -36,7 +36,7 @@ import {
 } from "./spoolman.js";
 import { calcFullConsumption, calcPartialConsumption, testFtpsConnection, resolveSliceSlots, orderedAmsSlots, printStageName, isPreparingStage } from "./gcode.js";
 import { consumptionCandidate, matchConsumption } from "./ams.js";
-import { setupMqtt, closeMqtt, broadcastSlotUpdate, broadcastSSE, testMqttConnection, resetOfflineBackoff, ACTIVE_STATES, printResultCleared, loadSliceInfo } from "./mqtt.js";
+import { setupMqtt, closeMqtt, broadcastSlotUpdate, broadcastSSE, testMqttConnection, resetOfflineBackoff, ACTIVE_STATES, printResultCleared, loadSliceInfo, ensureSliceInfo } from "./mqtt.js";
 import { getMappings, setMapping, clearMapping, clearPrinterMappings } from "./mappings.js";
 import {
     claimSlotLocation,
@@ -624,11 +624,17 @@ export function registerRoutes(app, printers) {
         // not there would otherwise cost one FTPS login per request for the
         // whole print. Measured on a P1S: 303 logins in fifteen minutes. The
         // manual ?job= test is the exception, it asks for exactly that.
+        //
+        // A fetch for the printer's own job is shared with the print handler
+        // through ensureSliceInfo(), so a request that lands while the job is
+        // preparing fetches the file once for both rather than once each.
         let sliceInfo = req.query.job || cleared ? null : (printer.currentSliceInfo || null);
         const alreadyLookedFor = !req.query.job && printer.lastSliceFetch?.jobName === jobName;
         if (jobName && !sliceInfo && !alreadyLookedFor) {
             try {
-                sliceInfo = await loadSliceInfo(printer, jobName, req.query.job ? null : printer.currentGcodeFile);
+                sliceInfo = req.query.job
+                    ? await loadSliceInfo(printer, jobName, null)
+                    : await ensureSliceInfo(printer, jobName, printer.currentGcodeFile);
             } catch (err) {
                 // non-fatal, surface the error in the response
                 return res.json({

--- a/test/gcode.studiomapping.test.js
+++ b/test/gcode.studiomapping.test.js
@@ -168,3 +168,37 @@ test("an echo for another job is not used, and a report is not mistaken for an e
     assert.equal(notePrintCommand(printer, Buffer.from('{"print":{"command":"project_file","subtask_name":"x"}}')), true);
     assert.equal(printer.pendingMapping, null);
 });
+
+// One download per print: the dashboard's request and the print handler share
+// it, and a file the dashboard already fetched is not fetched again at RUNNING.
+test("a file the dashboard already fetched is not fetched again when the print runs", async () => {
+    const { handlePrintStateChange } = await import("../src/mqtt.js");
+    const printer = { ...freshPrinter(), currentGcodeState: "PREPARE", currentJobName: "Würfel", sliceFetchDone: false };
+    printer.currentSliceInfo = { filaments: [{ index: 0 }], totalLayers: 3, rangesByFilamentIdx: {}, presets: [] };
+
+    await handlePrintStateChange(printer, { gcode_state: "RUNNING", subtask_name: "Würfel", layer_num: 0 });
+    assert.equal(printer.sliceFetchDone, true);
+    // fetchSliceInfo() records every attempt on lastSliceFetch before it
+    // connects, so an untouched record means no download was started
+    assert.equal(printer.lastSliceFetch, undefined);
+    assert.equal(printer.currentSliceInfo.totalLayers, 3);
+});
+
+test("two callers asking at once share one download", async () => {
+    const { ensureSliceInfo } = await import("../src/mqtt.js");
+    // No printer answers on this address, so the shared download fails fast;
+    // what matters is that the second caller gets the first caller's promise.
+    const printer = { ...freshPrinter(), ip: "127.0.0.1", code: "x", currentJobName: "Würfel" };
+
+    const first = ensureSliceInfo(printer, "Würfel", "Würfel.3mf");
+    const second = ensureSliceInfo(printer, "Würfel", "Würfel.3mf");
+    assert.equal(first, second);
+    assert.equal(printer.sliceFetchInFlight.jobName, "Würfel");
+
+    await Promise.allSettled([first, second]);
+    assert.equal(printer.sliceFetchInFlight, null);
+    // A different job is a different download
+    const other = ensureSliceInfo(printer, "Other", null);
+    assert.notEqual(other, first);
+    await Promise.allSettled([other]);
+});


### PR DESCRIPTION
## What

The sliced file of a print is downloaded once, not twice.

- The dashboard asks `/api/print` as soon as the job has a name, while the printer is still preparing, and that request fetched the file for itself. The print handler fetched it again three seconds later when the print reached RUNNING, and logged "Learned the preset" a second time.
- `ensureSliceInfo()` in `src/mqtt.js` keeps the first result on the printer and shares a download still in flight, so whichever of the two asks first downloads and the other reads. `freshStart` clears both, so a cached file never outlives its job. The manual `?job=` test still downloads for itself.
- The handler says `Print running: "Cube", slice info already loaded: 1 filament(s), 84 layers` when the dashboard got there first.

## Why now

Seen on the P2S on 2026-09-08 while testing #154: `Learned the preset` at 11:42:27 from the dashboard's request, `Slice info loaded` at 11:42:30 from the handler's own download of the same file.

## Verified

- `node --test`: 648 tests, 646 pass, 2 todo. Two new tests in `test/gcode.studiomapping.test.js`: a file the dashboard already fetched is not fetched again at RUNNING, and two callers asking at once share one promise.
- Not yet run against the printer; the next print on the P2S shows one download in the log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
