### PR TITLE
chore: version 1.3.0-dev.19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 -----------------------------------------------------------------------------------------------
-Unreleased
+Version 1.3.0-dev.19
    - Fixes:
       - A spool whose tag was edited by hand into something that is not JSON no longer stops every AMS update. The tag was read in three different ways, and the one in the slot loop threw on such a tag, inside the update, so every report after that ended in "Error processing message" and nothing was processed any more. One reader now, which takes the stored form and a bare UUID alike
       - The log no longer rewrites itself for every "nothing changed" line. Collapsing that line into the previous one read and wrote the whole file, once per update interval, up to a megabyte at a time, and made every tail on the file start over; only the last line is replaced now

--- a/OPEN.md
+++ b/OPEN.md
@@ -112,11 +112,13 @@ What was not:
   percentages whatever `MODE` says, manual only stops creating and merging.
 - [x] **The log detail dialog on a phone.** At 375 px on 2026-09-08 the dialog
   was 355 px wide, nothing reached past the edge and nothing scrolled sideways.
-- [ ] **The `errors` level with a real failure.** That an area switched off
-  cannot hide an error is proven on the running service; that an error still
-  reaches the file at the quietest level is covered only by
-  `test/logdetail.test.js`. It needs a failure provoked on purpose, for instance
-  by pointing the Spoolman endpoint at a dead port for a minute.
+- [x] **The `errors` level with a real failure.** Done on 2026-09-08 with the
+  mock printer and the Spoolman endpoint on a dead port (launch config
+  `mock-dead-spoolman`): with the level at `errors` and every area switched
+  off, "Spoolman is unreachable (ECONNREFUSED)" kept reaching the server log
+  every 30 seconds. Pointing the endpoint back at a live Spoolman brought the
+  service up, 25 slots processed, and neither log carried a single progress
+  line for it, only the `[ERROR]` lines of the scenario's unmatched spools.
 - [x] **`calcPartialConsumption()` and `layer_num`.** Settled on 2026-09-08
   through the capture and two deliberate cancels: `layer_num` is the layer
   being printed, counted from 1, it went to 1 in the second `stg_cur` went to

--- a/docs/changelog-1.3.0-draft.md
+++ b/docs/changelog-1.3.0-draft.md
@@ -6,7 +6,7 @@ between two builds. This file is the consolidated release block, written into
 CHANGELOG.md in place of those dev blocks when the release build is cut, not
 before.
 
-Every dev build after dev.18 has to be folded in here as well, or regenerate the
+Every dev build after dev.19 has to be folded in here as well, or regenerate the
 whole block from the dev blocks at release time.
 
 ## Draft
@@ -117,6 +117,16 @@ Version 1.3.0
       - A print is matched to the right slot when a slot in the middle of an AMS is empty, on a printer that does not report where the print runs from (P1 and A1 series). Bambu Studio leaves an empty slot out of the filament list, so every filament after a gap moves up one position; the service counted all four slots of every unit. Confirmed on an X1E emptied at A3, whose own report named A4 for the third filament. The external spool holder also comes before an AMS HT in that list (issue #146)
       - The print card no longer says "consumption booked" over a print that booked nothing. The label counts the report's rows now: "nothing booked", "1 of 3 booked", or "consumption booked" only when every used filament was
       - A print on a P1 or an A1 is booked onto the slots Bambu Studio sent it to, not onto an estimate. Those printers never report where a print runs from, and a reused project is remapped by colour when the job is sent; the printer echoes that command on its report topic, and the service reads it. A printer that reports its slots itself keeps that report; an SD card print or one repeated on the printer's screen keeps the estimate (issue #146)
+      - A cancelled print books the layers that were finished, not two more. The printer's layer_num is the layer being printed, counted from 1, and within a job the counter only goes up; measured on a P2S through the raw trace
+      - "After print" no longer subtracts a booked print a second time, and "On spool" and "After print" show the hundredth of a gram Spoolman holds, "267.45g" rather than "267g"
+      - A restart of the service during a print keeps the print's start time, written to printers/printstate.json when the print begins. The restart guard says what a restart really costs: the job is booked when it ends, on a P1 or an A1 the slots Bambu Studio sent it to are lost
+      - The sliced file of a print is downloaded once, not twice, when the dashboard asks for the print's figures before the print handler does
+      - A spool whose tag was edited by hand into something that is not JSON no longer stops every AMS update
+      - The log no longer rewrites itself for every "nothing changed" line; only the last line is replaced
+      - The slot update interval counts from every pass that ran, so a change in G-code mode does not trigger a Spoolman fetch on the very next report
+      - Five settings added after the environment was deprecated can be seeded from it like every other: AUTO_ASSIGN_THIRD_PARTY, PRINT_RESET_MINUTES, ARCHIVE_EMPTY_SPOOLS, EMPTY_SPOOL_THRESHOLD and OFFLINE_MAX_INTERVAL; a test holds the seed list against the schema
+      - An original AMS is not offered a dryer. An original AMS on current firmware sends the dryer fields, an X1E's AMS08 did in every report of a trace, so the model from the printer's module list decides now and the report only until that answer is in
+      - Web UI: "Go to Spoolman" opens the create page when Spoolman lives under a path; spool, filament and slot names, log lines and the printer name in the export dialog are shown as text rather than markup; the merge dialog and the spool dialog round to two decimals; the footer says the current year; the two theme icons are drawn in the page rather than fetched from icons8.com
    - Development:
       - Node 22, and the README is rebuilt around G-code tracking with new screenshots
       - One projection for what a client sees of a slot, one consumption match, and the rules both sides apply live in public/shared.js instead of in two implementations
@@ -128,5 +138,8 @@ Version 1.3.0
       - Twelve real printer reports, copied from the mock data of ha-bambulab under its MIT notice in THIRD_PARTY_NOTICES.md: A1 with AMS Lite, X1C with three AMS and an AMS HT, the dual nozzle H2C, H2D and X2D, P1P without AMS, A2L and P2S. test/reports.test.js runs every one through the ingest pipeline with invariants, and what they found that is not handled yet is listed there as todo: the A2L reports its AMS as unit 16, which no slot label range knows, so the README lists it as untested
       - The test suite runs on node:test and covers public/ for the first time
       - The release notes of every version carry the merged pull requests grouped by the label they were given, configured in .github/release.yml, with the breaking ones first. The release body opens with that list and ends with the changelog section, rather than burying the list under sixty lines of prose
+      - The printer runtime object in src/printers.js declares every field the code assigns to it. One reader for a spool's tag, one sentence table for a refused, timed out or unreachable connection, one FTPS login, one retry limit check, one Spoolman monitor and one JSON file store behind the assignments, the learned presets, the print starts and the API keys; each was two to five copies. Thirteen exports nobody imported are plain functions again
+      - The weight a slot carries to the dashboard has one meaning: amsWeight is what the AMS reads off the RFID tag, and the dashboard reads Spoolman's weight off the linked spool itself
+      - Web UI: the toast after an action is styled by a class, the event handler in frontend.js is indented like the rest of the file, and the logs page and the menu parse their inputs once
 
 -----------------------------------------------------------------------------------------------

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bambulab-ams-spoolman-filamentstatus",
-  "version": "1.3.0-dev.18",
+  "version": "1.3.0-dev.19",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bambulab-ams-spoolman-filamentstatus",
-      "version": "1.3.0-dev.18",
+      "version": "1.3.0-dev.19",
       "license": "ISC",
       "dependencies": {
         "adm-zip": "^0.6.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "mqtt": "^5.15.2"
   },
   "name": "bambulab-ams-spoolman-filamentstatus",
-  "version": "1.3.0-dev.18",
+  "version": "1.3.0-dev.19",
   "main": "app.js",
   "type": "module",
   "engines": {

--- a/src/config.js
+++ b/src/config.js
@@ -37,7 +37,7 @@ export const apiKeysPath = path.join(dataDir, "apikeys.json");
 // brings the service back on its own or depends on the container policy.
 export const supervised = process.env.SUPERVISED === "1";
 
-export const version = "1.3.0-dev.18";
+export const version = "1.3.0-dev.19";
 export const PORT = 4000;
 
 /** The spellings a boolean environment variable is accepted in. */


### PR DESCRIPTION
Version bump for the dev build carrying #158 to #165.

- `package.json`, `package-lock.json` (two places) and `src/config.js` say `1.3.0-dev.19`.
- `CHANGELOG.md`: the `Unreleased` block becomes `Version 1.3.0-dev.19`.
- `docs/changelog-1.3.0-draft.md`: the dev.19 entries are folded into the Fixes and Development sections, and the note says "after dev.19".
- `OPEN.md`: the `errors` level with a real failure is ticked, run on 2026-09-08 against a dead Spoolman port with the mock printer.

Tests: 664, 662 pass, 2 todo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)