### PR TITLE
chore: version 1.3.0-dev.20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 -----------------------------------------------------------------------------------------------
-Unreleased
+Version 1.3.0-dev.20
    - Features:
       - The API has a page of its own in the Web UI, opened with the info button next to the API keys on the settings page: every route with its parameters, an example body and the shapes of its answers, and a "Send" button per route that sends the request from the browser and shows the status, the headers and the answer. A path parameter is prefilled with a real serial number, the event stream is followed live, a download opens as one, and the routes that end the process or remove something ask first. A bar that stays at the top carries a filter over the list, and a curl line under every request carries the key typed at the top so it can be copied into a script as it will be run there
          - The description behind it is served as OpenAPI 3.0 at /api/openapi.json and imports into Swagger UI, Postman, Bruno or a client generator. Written by hand in src/openapi.js next to the routes; a test holds it to the routes the app registers, in both directions, so a route added without a description fails the suite

--- a/docs/changelog-1.3.0-draft.md
+++ b/docs/changelog-1.3.0-draft.md
@@ -6,7 +6,7 @@ between two builds. This file is the consolidated release block, written into
 CHANGELOG.md in place of those dev blocks when the release build is cut, not
 before.
 
-Every dev build after dev.19 has to be folded in here as well, or regenerate the
+Every dev build after dev.20 has to be folded in here as well, or regenerate the
 whole block from the dev blocks at release time.
 
 ## Draft
@@ -90,6 +90,7 @@ Version 1.3.0
       - The create dialog of a chipless slot proposes the filament from the slot's preset. A vendor preset chosen in Bambu Studio, "SUNLU PETG" or "PolyLite PETG", names the manufacturer, so the catalogue is narrowed to that maker and the slot's material when the dialog opens, and the entry nearest the slot's colour is filled in as a proposal with a line saying how near. A filament sold on a spool heavier than 1 kg cannot sit in an AMS and ranks behind every fitting one; the external holder takes any size. Nothing is created by itself, and a Bambu, a generic or a custom preset names no manufacturer, so the dialog then starts as before (issue #47)
       - The name behind a custom preset is learned from the first print with it. A preset from Bambu Studio's cloud library, or one of the user's own, reaches the slot as a hash such as "Pdd34802", and the printer never sends the name; the sliced file does, next to the id and the vendor, and the service downloads that file for every print it books. The slot then reads "fibrelogy PLA Basic preset" instead of "PLA · custom preset", and the create dialog knows the manufacturer. Kept in printers/presets.json and in the diagnostics bundle (issue #47)
    - Fixes:
+      - The service starts on Windows. starting.js imported backend.js through its absolute path, which Node's module loader reads as a URL with the scheme "d:" and refuses; both dynamic imports go through a file URL now
       - A spool is created with the weight the AMS reports instead of always starting at 100 % (issue #59)
       - Consumption is booked onto the right spool when two loaded spools look alike, and no longer onto a spool that never printed it
       - Multi colour spools show all of their colours, and a gradient spool is no longer taken for a plain spool of the same first colour

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bambulab-ams-spoolman-filamentstatus",
-  "version": "1.3.0-dev.19",
+  "version": "1.3.0-dev.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bambulab-ams-spoolman-filamentstatus",
-      "version": "1.3.0-dev.19",
+      "version": "1.3.0-dev.20",
       "license": "ISC",
       "dependencies": {
         "adm-zip": "^0.6.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "mqtt": "^5.15.2"
   },
   "name": "bambulab-ams-spoolman-filamentstatus",
-  "version": "1.3.0-dev.19",
+  "version": "1.3.0-dev.20",
   "main": "app.js",
   "type": "module",
   "engines": {

--- a/src/config.js
+++ b/src/config.js
@@ -37,7 +37,7 @@ export const apiKeysPath = path.join(dataDir, "apikeys.json");
 // brings the service back on its own or depends on the container policy.
 export const supervised = process.env.SUPERVISED === "1";
 
-export const version = "1.3.0-dev.19";
+export const version = "1.3.0-dev.20";
 export const PORT = 4000;
 
 /** The spellings a boolean environment variable is accepted in. */


### PR DESCRIPTION
Version bump for the next dev build.

- `package.json`, `package-lock.json` and `src/config.js` say 1.3.0-dev.20.
- The Unreleased block in `CHANGELOG.md` becomes Version 1.3.0-dev.20: the API page with its OpenAPI document, and the Windows start fix.
- The 1.3.0 draft carries the Windows fix under Fixes and names dev.20 as the last folded in build.

`npm test`: 666 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CBXxW1YS9TqNemoCvYxVRs)_