### PR TITLE
fix: a P1S is tracked between its full reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,12 @@
 -----------------------------------------------------------------------------------------------
+Unreleased
+   - Fixes:
+      - A P1S or an A1 is tracked between its full reports. Those printers send a full report every one to five minutes and only what changed in between, and the print tracking ran on reports with a gcode_state only, so a layer sent on its own, the stage, the remaining time and the error code were dropped. Measured on a P1S through the raw trace on 2026-09-09: FINISH was logged at "layer 17" while the printer had counted to 38, a cancel would have booked a layer minutes old, and the dashboard's layer stood still between the full reports. A delta is read as one more report of the state last seen; nothing changes for a P2S or an X1, which repeat the whole print block every time
+         - The error a P1S names three seconds before FAILED, in a delta of its own, now reaches the print's summary
+         - A job with the same name as the last one is named at its start after a restart of the service. The P1S leaves subtask_name out of the report that starts it, nothing remembered the name, and the slice fetch waited "unnamed" for the next full report, three and a half minutes into a nine minute print. The project_file echo Bambu Studio's job arrived with names it, and is read at a start when the report does not
+      - The diagnostics export masks the upload address in the Studio echo. A cloud print's project_file command, echoed by the printer into the MQTT trace, carries a signed link into Bambu's upload bucket whose path is the user's cloud account id; only the host survives now, and a LAN print's ftp address stays as it is
+
+-----------------------------------------------------------------------------------------------
 Version 1.3.0-dev.20
    - Features:
       - The API has a page of its own in the Web UI, opened with the info button next to the API keys on the settings page: every route with its parameters, an example body and the shapes of its answers, and a "Send" button per route that sends the request from the browser and shows the status, the headers and the answer. A path parameter is prefilled with a real serial number, the event stream is followed live, a download opens as one, and the routes that end the process or remove something ask first. A bar that stays at the top carries a filter over the list, and a curl line under every request carries the key typed at the top so it can be copied into a script as it will be run there

--- a/src/anonymize.js
+++ b/src/anonymize.js
@@ -47,6 +47,12 @@ const JSON_TAG = /("(?:tray_uuid|tag)"\s*:\s*")((?:\\"|[^"])*)(")/g;
 // A tag of a current AMS is 32 hex characters, which nothing else in a log is,
 // so this catches one wherever it turns up without an anchor to hold on to.
 const LONG_TAG = /\b[0-9A-F]{32}\b/g;
+// The address a cloud print is fetched from, echoed by the printer in the
+// project_file command Bambu Studio sent and so written into the MQTT trace: a
+// signed link into Bambu's upload bucket whose path carries the user's cloud
+// account id and whose query carries the signature. Neither is of any use in
+// a report; the host says which cloud the print came through and stays.
+const JSON_URL = /("url"\s*:\s*")(https?:\/\/[^"]*)(")/g;
 
 /** The placeholders a slot reports instead of a tag. Neither identifies a spool. */
 function isTagPlaceholder(value) {
@@ -173,6 +179,28 @@ export function maskUrl(value) {
 }
 
 /**
+ * Reduces a cloud upload address to its host.
+ *
+ * `maskUrl` keeps the path and the query because a wrong port or a forgotten
+ * subfolder is what a Spoolman address report is about. The address in a
+ * project_file echo is the opposite case: the path is the user's cloud account
+ * id and the upload's model id, the query is an AWS signature, and the only
+ * thing worth reading is which host it points at.
+ *
+ * @param {string} value - the URL
+ * @returns {string} the scheme and the host, followed by the mask
+ */
+export function maskCloudUrl(value) {
+    let url;
+    try {
+        url = new URL(String(value ?? ""));
+    } catch {
+        return MASKED_CODE;
+    }
+    return `${url.protocol}//${url.host}/${MASKED_CODE}`;
+}
+
+/**
  * Shortens a file system path to its last two segments.
  *
  * A container path is `/app/printers` and says nothing, but the same service run
@@ -267,6 +295,7 @@ export function maskText(text, known = {}) {
     }
 
     out = out.replace(IPV4, (match, a, b, c) => `${a}.${b}.${c}.XXX`);
+    out = out.replace(JSON_URL, (match, head, value, tail) => head + maskCloudUrl(value) + tail);
 
     return out;
 }

--- a/src/mqtt.js
+++ b/src/mqtt.js
@@ -309,6 +309,46 @@ const TERMINAL_STATES = new Set(["FINISH", "FAILED", "CANCEL"]);
 export const ACTIVE_STATES = new Set(ACTIVE_PRINT_STATES);
 
 /**
+ * The fields of a report that `handlePrintStateChange()` reads next to
+ * `gcode_state`. A report carrying none of them has nothing to say about the
+ * print, whatever else is in it.
+ */
+const PRINT_DELTA_FIELDS = [
+    "layer_num", "subtask_name", "gcode_file", "stg_cur", "mc_remaining_time",
+    "print_error", "mc_print_error_code", "fail_reason", "mapping",
+];
+
+/**
+ * A delta report completed with the state the printer last named, or null
+ * when it is not one the print tracking should see.
+ *
+ * A P1S or an A1 sends a full report every one to five minutes and, in
+ * between, only what changed: `layer_num` on its own, `gcode_file` on its
+ * own, and `subtask_name` not at all when the job has the same name as the
+ * last one. A P2S or an X1 repeats the whole print block every time. The
+ * tracking used to run on reports with a `gcode_state` only, which dropped
+ * every one of those deltas. Measured on a P1S through the raw trace on
+ * 2026-09-09: FINISH was logged at "layer 17" while the deltas had counted to
+ * 38, so a cancel would have booked a layer minutes old, and the dashboard's
+ * layer, stage and remaining time stood still between the full reports.
+ *
+ * An omitted field means "unchanged" on those printers, so a delta is read as
+ * one more report of the state last seen. Nothing is known before the first
+ * report with a state, and that first report has a rule of its own (it may
+ * find a print already running), so a delta ahead of it is dropped as before.
+ *
+ * @param {object} printer - the printer runtime object
+ * @param {object} print - the `print` block of the report, without a state
+ * @returns {object|null} the block with the last known state, or null
+ */
+export function deltaAsReport(printer, print) {
+    if (!print || typeof print !== "object" || print.gcode_state) return null;
+    if (!printer.stateSeenSinceStart || !printer.currentGcodeState) return null;
+    if (!PRINT_DELTA_FIELDS.some(field => print[field] !== undefined)) return null;
+    return { ...print, gcode_state: printer.currentGcodeState };
+}
+
+/**
  * Tracks gcode_state transitions and triggers filament consumption tracking.
  * Called on every MQTT message that contains a gcode_state field.
  *
@@ -327,10 +367,6 @@ export const ACTIVE_STATES = new Set(ACTIVE_PRINT_STATES);
  */
 export async function handlePrintStateChange(printer, print) {
     const newState    = print.gcode_state;
-    // subtask_name is the job name used for the FTP file (/cache/<name>.gcode.3mf).
-    // gcode_file (e.g. /data/Metadata/plate_1.gcode) is an internal path NOT
-    // exposed over FTP, so we only fall back to its basename as a last resort.
-    const jobName     = print.subtask_name || printer.currentJobName || null;
     const prevState   = printer.currentGcodeState || "IDLE";
     // The first report after the service started is the one that may find a
     // print already running, whose start was measured by the process before.
@@ -341,6 +377,21 @@ export async function handlePrintStateChange(printer, print) {
     // active one. Reset tracking there (even on a reprint of the same file) so
     // consumption gets booked again for the new run.
     const freshStart = ACTIVE_STATES.has(newState) && !ACTIVE_STATES.has(prevState);
+
+    // subtask_name is the job name used for the FTP file (/cache/<name>.gcode.3mf).
+    // gcode_file (e.g. /data/Metadata/plate_1.gcode) is an internal path NOT
+    // exposed over FTP, so we only fall back to its basename as a last resort.
+    //
+    // A P1S leaves subtask_name out of the report that starts a job when the
+    // job has the same name as the last one, because it only sends what
+    // changed. After a restart of the service nothing remembers that name, and
+    // the job was "unnamed" until the next full report minutes later, with the
+    // slice fetch waiting on it. The project_file echo Bambu Studio's job
+    // arrived with names it, so that is the second source at a start.
+    const jobName = print.subtask_name
+        || (freshStart ? printer.pendingMapping?.jobName : null)
+        || printer.currentJobName
+        || null;
 
     // The layer for the partial booking and the dashboard, read off every
     // report with three rules measured on a P2S through the raw trace:
@@ -458,7 +509,12 @@ export async function handlePrintStateChange(printer, print) {
     // else, including nothing at all, it has moved on and whatever comes after
     // belongs to this print. An identical error really happening again inside
     // this print is only missed while the old one has not been cleared once.
-    if (printer.staleErrorText && reported !== printer.staleErrorText) {
+    //
+    // Only a report that names the error fields at all can say the printer has
+    // moved on. A P1S delta leaves them out when they did not change, which
+    // must not read as "cleared".
+    const namesError = "print_error" in print || "mc_print_error_code" in print || "fail_reason" in print;
+    if (printer.staleErrorText && namesError && reported !== printer.staleErrorText) {
         printer.staleErrorText = null;
     }
 
@@ -1082,8 +1138,9 @@ async function handleMqttMessage(printer, topic, message) {
             // the G-code tracking must stay out of it entirely. Running both
             // would download the sliced file on every print and book consumption
             // that the next AMS update then overwrites again.
-            if (!legacyMode() && data?.print?.gcode_state) {
-                await handlePrintStateChange(printer, data.print);
+            if (!legacyMode()) {
+                const report = data?.print?.gcode_state ? data.print : deltaAsReport(printer, data?.print);
+                if (report) await handlePrintStateChange(printer, report);
             }
 
             debug("mqtt", printer.name, printer.logFilePath, "Check if message contains AMS Data");

--- a/test/anonymize.test.js
+++ b/test/anonymize.test.js
@@ -10,6 +10,7 @@ import {
     maskPath,
     maskSerial,
     maskTag,
+    maskCloudUrl,
     maskText,
     maskUrl,
 } from "../src/anonymize.js";
@@ -175,4 +176,26 @@ test("only the settings that carry an address are masked", () => {
     assert.equal(masked.MODE, "automatic");
 
     assert.deepEqual(exportSettings(values, false), values);
+});
+
+test("the upload address in a Studio echo keeps its host and nothing else", () => {
+    const line = '2026-09-09_16:55:23 {"print":{"command":"project_file","subtask_name":"Würfel","ams_mapping":[0,1,3],'
+        + '"url":"https://or-cloud-upload-prod.s3.us-west-2.amazonaws.com/users/2160108466/models/20260909225520.711/USf0c790810afb1e_988629317_1.3mf'
+        + '?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAXY6FH2ERJ3UALUNL%2F20260909%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Signature=e46388b1561a2c87","reason":"success"}}';
+    const masked = maskText(line);
+    assert.ok(masked.includes('"url":"https://or-cloud-upload-prod.s3.us-west-2.amazonaws.com/XXX"'), masked);
+    assert.ok(!masked.includes("2160108466"));
+    assert.ok(!masked.includes("X-Amz-Signature"));
+    // The rest of the echo is what a report is about and stays
+    assert.ok(masked.includes('"ams_mapping":[0,1,3]'));
+});
+
+test("a LAN print's address in a Studio echo is not a cloud address and stays", () => {
+    const line = '{"print":{"command":"project_file","url":"ftp:///cache/Cube.gcode.3mf"}}';
+    assert.equal(maskText(line), line);
+});
+
+test("a cloud address that is not a URL is masked whole", () => {
+    assert.equal(maskCloudUrl("not a url"), "XXX");
+    assert.equal(maskCloudUrl("https://example.com:8443/a/b?c=d"), "https://example.com:8443/XXX");
 });

--- a/test/printstate.test.js
+++ b/test/printstate.test.js
@@ -6,7 +6,7 @@ import path from "path";
 
 // The module reads its path from config.js at import time, so DATA_DIR has to
 // point at a throwaway directory before the first import.
-let dir, printStatePath, rememberPrintStart, recallPrintStart, forgetPrintStart, resetPrintStateForTests, handlePrintStateChange;
+let dir, printStatePath, rememberPrintStart, recallPrintStart, forgetPrintStart, resetPrintStateForTests, handlePrintStateChange, deltaAsReport;
 
 before(async () => {
     dir = fs.mkdtempSync(path.join(os.tmpdir(), "ams-printstate-"));
@@ -17,7 +17,7 @@ before(async () => {
 
     ({ printStatePath } = await import("../src/config.js"));
     ({ rememberPrintStart, recallPrintStart, forgetPrintStart, resetPrintStateForTests } = await import("../src/printstate.js"));
-    ({ handlePrintStateChange } = await import("../src/mqtt.js"));
+    ({ handlePrintStateChange, deltaAsReport } = await import("../src/mqtt.js"));
 });
 
 after(() => { fs.removeSync(dir); });
@@ -120,5 +120,81 @@ test("the first report after the service came up takes the running print's layer
     const p = printer();
     await handlePrintStateChange(p, { gcode_state: "RUNNING", subtask_name: "Cube", layer_num: 7 });
     assert.equal(p.currentLayerNum, 7);
+    forgetPrintStart("SERIAL");
+});
+
+// A P1S sends a full report every few minutes and only what changed in between.
+// The deltas below are taken from the raw trace of 2026-09-09: layer_num on its
+// own, print_error three seconds ahead of FAILED, and a job start without
+// subtask_name because the name had not changed.
+
+test("a delta with only the layer is read as a report of the running state", async () => {
+    const p = printer();
+    await handlePrintStateChange(p, { gcode_state: "IDLE" });
+    await handlePrintStateChange(p, { gcode_state: "RUNNING", subtask_name: "Cube", layer_num: 0 });
+
+    const delta = deltaAsReport(p, { layer_num: 5 });
+    assert.equal(delta.gcode_state, "RUNNING");
+    await handlePrintStateChange(p, delta);
+    assert.equal(p.currentLayerNum, 5);
+
+    // A full report with a stale layer next to it does not pull it back
+    await handlePrintStateChange(p, { gcode_state: "RUNNING", subtask_name: "Cube", layer_num: 4 });
+    assert.equal(p.currentLayerNum, 5);
+
+    await handlePrintStateChange(p, { gcode_state: "FAILED", subtask_name: "Cube" });
+    assert.equal(p.lastPrintSummary.layerNum, 5);
+    forgetPrintStart("SERIAL");
+});
+
+test("a delta ahead of the first report with a state is dropped, so the restart rule still holds", async () => {
+    const p = printer();
+    assert.equal(deltaAsReport(p, { layer_num: 7 }), null);
+    await handlePrintStateChange(p, { gcode_state: "RUNNING", subtask_name: "Cube", layer_num: 7 });
+    assert.equal(p.currentLayerNum, 7);
+    forgetPrintStart("SERIAL");
+});
+
+test("a delta that says nothing about the print is dropped", async () => {
+    const p = printer();
+    await handlePrintStateChange(p, { gcode_state: "IDLE" });
+    assert.equal(deltaAsReport(p, { bed_temper: 40, wifi_signal: "-48dBm" }), null);
+    assert.equal(deltaAsReport(p, { gcode_state: "RUNNING" }), null);
+    assert.equal(deltaAsReport(p, null), null);
+});
+
+test("the error a P1S names in a delta before FAILED lands in the summary", async () => {
+    const p = printer();
+    await handlePrintStateChange(p, { gcode_state: "IDLE", print_error: 0 });
+    await handlePrintStateChange(p, { gcode_state: "RUNNING", subtask_name: "Cube", layer_num: 0, print_error: 0 });
+    await handlePrintStateChange(p, deltaAsReport(p, { print_error: 50348044 }));
+    await handlePrintStateChange(p, { gcode_state: "FAILED" });
+    assert.match(p.lastPrintSummary.printError, /^Printer error 50348044/);
+    forgetPrintStart("SERIAL");
+});
+
+test("a delta without the error fields does not clear the error the print started with", async () => {
+    const p = printer();
+    await handlePrintStateChange(p, { gcode_state: "FAILED", print_error: 50348044 });
+    // The report that starts the next print still carries the old complaint
+    await handlePrintStateChange(p, { gcode_state: "RUNNING", subtask_name: "Cube", layer_num: 0, print_error: 50348044 });
+    await handlePrintStateChange(p, deltaAsReport(p, { layer_num: 1 }));
+    assert.equal(p.lastPrintError, null);
+    // Only a report that names the field again moves the printer on
+    await handlePrintStateChange(p, deltaAsReport(p, { print_error: 0 }));
+    await handlePrintStateChange(p, deltaAsReport(p, { print_error: 50348044 }));
+    assert.match(p.lastPrintError, /^Printer error 50348044/);
+    forgetPrintStart("SERIAL");
+});
+
+test("a job with the same name as the last one takes its name from the Studio echo", async () => {
+    // After a restart nothing remembers the last name, and the P1S leaves
+    // subtask_name out of the report that starts the job
+    const p = printer({ currentJobName: null, pendingMapping: { jobName: "Würfel", slots: ["A1", "A3", "A4"] } });
+    await handlePrintStateChange(p, { gcode_state: "FAILED", subtask_name: "Würfel" });
+    await handlePrintStateChange(p, { gcode_state: "PREPARE", gcode_file: "Würfel.3mf" });
+    assert.equal(p.currentJobName, "Würfel");
+    assert.equal(p.currentGcodeFile, "Würfel.3mf");
+    assert.deepEqual(p.currentMapping, ["A1", "A3", "A4"]);
     forgetPrintStart("SERIAL");
 });


### PR DESCRIPTION
A P1S or an A1 sends a full report every one to five minutes and only what changed in between. The print tracking ran on reports with a `gcode_state` only, so a layer sent on its own, the stage, the remaining time and the error code were dropped. Seen in the trace of issue #146 on 2026-09-09: FINISH was logged at "layer 17" while the printer had counted to 38, a cancel would have booked a layer minutes old, and the dashboard's layer stood still between full reports.

- `deltaAsReport()` reads a delta as one more report of the state last seen. Nothing changes for a P2S or an X1, which repeat the whole print block every time
- The error a P1S names in a delta before FAILED reaches the summary
- A job with the same name as the last one is named at its start after a restart of the service, from the `project_file` echo
- The diagnostics export reduces the upload address in the Studio echo to its host. The path carried the user's Bambu cloud account id

Replay of the real trace through the new path: PREPARE named from the echo, FINISH at layer 38. Not yet proven on a live printer.